### PR TITLE
feat(#52): Soft delete, hide-for-me & delete confirmation dialog

### DIFF
--- a/infra/db/schema.sql
+++ b/infra/db/schema.sql
@@ -370,3 +370,16 @@ CREATE TABLE IF NOT EXISTS notifications (
 
 CREATE INDEX IF NOT EXISTS idx_notifications_user ON notifications(user_id, is_read, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_notifications_user_unread ON notifications(user_id) WHERE is_read = FALSE;
+
+-- 25. Soft delete for messages (Issue #52)
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS deleted_by UUID REFERENCES users(id) ON DELETE SET NULL;
+
+-- 26. User Hidden Messages (Delete for Me) (Issue #52)
+CREATE TABLE IF NOT EXISTS user_hidden_messages (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    message_id UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    hidden_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, message_id)
+);
+CREATE INDEX IF NOT EXISTS idx_user_hidden_messages_user ON user_hidden_messages(user_id);

--- a/services/bifrost/cmd/gateway/main.go
+++ b/services/bifrost/cmd/gateway/main.go
@@ -206,6 +206,7 @@ func main() {
 			authenticated.GET("/channels/:id/messages/:messageId/replies", messagingHandler.GetThreadReplies)
 			authenticated.PATCH("/channels/:id/messages/:messageId", messagingHandler.EditMessage)
 			authenticated.DELETE("/channels/:id/messages/:messageId", messagingHandler.DeleteMessage)
+			authenticated.POST("/channels/:id/messages/:messageId/hide", messagingHandler.HideMessage)
 			authenticated.GET("/channels/:id/messages/:messageId/history", messagingHandler.GetMessageEditHistory)
 			authenticated.POST("/channels/:id/messages/:messageId/react", messagingHandler.ReactToMessage)
 			authenticated.POST("/channels/:id/messages/:messageId/pin", messagingHandler.TogglePin)

--- a/services/bifrost/internal/messaging/handler.go
+++ b/services/bifrost/internal/messaging/handler.go
@@ -324,6 +324,27 @@ func (h *MessagingHandler) DeleteMessage(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "deleted", "message_id": messageID})
 }
 
+func (h *MessagingHandler) HideMessage(c *gin.Context) {
+	_, userID := getAuthInfo(c)
+	if userID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	messageID := c.Param("messageId")
+	if messageID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Message ID required"})
+		return
+	}
+
+	if err := h.service.HideMessage(c.Request.Context(), messageID, userID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "hidden", "message_id": messageID})
+}
+
 func (h *MessagingHandler) GetMessageEditHistory(c *gin.Context) {
 	messageID := c.Param("messageId")
 	if messageID == "" {

--- a/services/bifrost/internal/messaging/models.go
+++ b/services/bifrost/internal/messaging/models.go
@@ -34,6 +34,8 @@ type Message struct {
 	UserReactions []string       `json:"user_reactions,omitempty"`
 	IsPinned      bool           `json:"is_pinned"`
 	IsBookmarked  bool           `json:"is_bookmarked"`
+	IsDeleted     bool           `json:"is_deleted,omitempty"`
+	DeletedAt     *time.Time     `json:"deleted_at,omitempty"`
 	CreatedAt     time.Time      `json:"created_at"`
 	UpdatedAt     time.Time      `json:"updated_at"`
 }

--- a/services/bifrost/internal/messaging/service.go
+++ b/services/bifrost/internal/messaging/service.go
@@ -205,41 +205,35 @@ func (s *MessagingService) GetMessagesByChannel(ctx context.Context, channelID s
 	var query string
 	var args []interface{}
 
-	if before != "" {
-		query = `
-			SELECT 
-				m.id, m.channel_id, m.user_id, u.username, m.parent_id, m.reply_to, m.forward_source_id,
+	// Base columns include deleted_at for tombstone rendering
+	baseColumns := `m.id, m.channel_id, m.user_id, u.username, m.parent_id, m.reply_to, m.forward_source_id,
 				fsu.username as forward_source_username,
-				m.content_md, m.content_html, m.created_at, m.updated_at, m.is_edited,
-				(SELECT COUNT(*) FROM messages r WHERE r.parent_id = m.id) as reply_count,
-				EXISTS(SELECT 1 FROM channel_pins cp WHERE cp.message_id = m.id) as is_pinned,
-				EXISTS(SELECT 1 FROM user_bookmarks ub WHERE ub.message_id = m.id AND ub.user_id = $3) as is_bookmarked
-			FROM messages m
+				m.content_md, m.content_html, m.created_at, m.updated_at, m.is_edited, m.deleted_at,
+				(SELECT COUNT(*) FROM messages r WHERE r.parent_id = m.id AND r.deleted_at IS NULL) as reply_count,
+				EXISTS(SELECT 1 FROM channel_pins cp WHERE cp.message_id = m.id) as is_pinned`
+	baseJoin := `FROM messages m
 			JOIN users u ON m.user_id = u.id
 			LEFT JOIN messages fsm ON m.forward_source_id = fsm.id
-			LEFT JOIN users fsu ON fsm.user_id = fsu.id
+			LEFT JOIN users fsu ON fsm.user_id = fsu.id`
+	hiddenFilter := `AND NOT EXISTS (SELECT 1 FROM user_hidden_messages uhm WHERE uhm.user_id = %s AND uhm.message_id = m.id)`
+
+	if before != "" {
+		query = `SELECT ` + baseColumns + `,
+				EXISTS(SELECT 1 FROM user_bookmarks ub WHERE ub.message_id = m.id AND ub.user_id = $3) as is_bookmarked
+			` + baseJoin + `
 			WHERE m.channel_id = $1 AND m.parent_id IS NULL AND m.created_at < $2::timestamp
+			` + fmt.Sprintf(hiddenFilter, "$3") + `
 			ORDER BY m.created_at DESC
-			LIMIT 50
-		`
+			LIMIT 50`
 		args = []interface{}{channelID, before, currentUserID}
 	} else {
-		query = `
-			SELECT 
-				m.id, m.channel_id, m.user_id, u.username, m.parent_id, m.reply_to, m.forward_source_id,
-				fsu.username as forward_source_username,
-				m.content_md, m.content_html, m.created_at, m.updated_at, m.is_edited,
-				(SELECT COUNT(*) FROM messages r WHERE r.parent_id = m.id) as reply_count,
-				EXISTS(SELECT 1 FROM channel_pins cp WHERE cp.message_id = m.id) as is_pinned,
+		query = `SELECT ` + baseColumns + `,
 				EXISTS(SELECT 1 FROM user_bookmarks ub WHERE ub.message_id = m.id AND ub.user_id = $2) as is_bookmarked
-			FROM messages m
-			JOIN users u ON m.user_id = u.id
-			LEFT JOIN messages fsm ON m.forward_source_id = fsm.id
-			LEFT JOIN users fsu ON fsm.user_id = fsu.id
+			` + baseJoin + `
 			WHERE m.channel_id = $1 AND m.parent_id IS NULL
+			` + fmt.Sprintf(hiddenFilter, "$2") + `
 			ORDER BY m.created_at DESC
-			LIMIT 50
-		`
+			LIMIT 50`
 		args = []interface{}{channelID, currentUserID}
 	}
 
@@ -255,8 +249,14 @@ func (s *MessagingService) GetMessagesByChannel(ctx context.Context, channelID s
 	var messages []Message
 	for rows.Next() {
 		var msg Message
-		if err := rows.Scan(&msg.ID, &msg.ChannelID, &msg.UserID, &msg.Username, &msg.ParentID, &msg.ReplyTo, &msg.ForwardSourceID, &msg.ForwardSourceUsername, &msg.ContentMD, &msg.ContentHTML, &msg.CreatedAt, &msg.UpdatedAt, &msg.IsEdited, &msg.ReplyCount, &msg.IsPinned, &msg.IsBookmarked); err != nil {
+		if err := rows.Scan(&msg.ID, &msg.ChannelID, &msg.UserID, &msg.Username, &msg.ParentID, &msg.ReplyTo, &msg.ForwardSourceID, &msg.ForwardSourceUsername, &msg.ContentMD, &msg.ContentHTML, &msg.CreatedAt, &msg.UpdatedAt, &msg.IsEdited, &msg.DeletedAt, &msg.ReplyCount, &msg.IsPinned, &msg.IsBookmarked); err != nil {
 			return nil, err
+		}
+		// For deleted messages, clear content and mark as deleted (tombstone)
+		if msg.DeletedAt != nil {
+			msg.IsDeleted = true
+			msg.ContentMD = ""
+			msg.ContentHTML = ""
 		}
 		messages = append(messages, msg)
 	}
@@ -416,7 +416,7 @@ func (s *MessagingService) EditMessage(ctx context.Context, messageID string, us
 func (s *MessagingService) DeleteMessage(ctx context.Context, messageID string, userID string) error {
 	// Verify author
 	var authorID, channelID string
-	err := s.db.Pool.QueryRow(ctx, "SELECT user_id, channel_id FROM messages WHERE id = $1", messageID).Scan(&authorID, &channelID)
+	err := s.db.Pool.QueryRow(ctx, "SELECT user_id, channel_id FROM messages WHERE id = $1 AND deleted_at IS NULL", messageID).Scan(&authorID, &channelID)
 	if err != nil {
 		return err
 	}
@@ -424,8 +424,8 @@ func (s *MessagingService) DeleteMessage(ctx context.Context, messageID string, 
 		return pgx.ErrNoRows
 	}
 
-	// Delete the message (cascade will handle edits, pins, bookmarks)
-	_, err = s.db.Pool.Exec(ctx, "DELETE FROM messages WHERE id = $1", messageID)
+	// Soft delete the message
+	_, err = s.db.Pool.Exec(ctx, "UPDATE messages SET deleted_at = NOW(), deleted_by = $2 WHERE id = $1", messageID, userID)
 	if err != nil {
 		return err
 	}
@@ -437,6 +437,15 @@ func (s *MessagingService) DeleteMessage(ctx context.Context, messageID string, 
 	})
 
 	return nil
+}
+
+// HideMessage hides a message for the current user only ("Delete for Me").
+func (s *MessagingService) HideMessage(ctx context.Context, messageID string, userID string) error {
+	_, err := s.db.Pool.Exec(ctx,
+		`INSERT INTO user_hidden_messages (user_id, message_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+		userID, messageID,
+	)
+	return err
 }
 
 func (s *MessagingService) GetMessageEditHistory(ctx context.Context, messageID string) ([]MessageEdit, error) {

--- a/ui/e2e/messaging_crud.spec.ts
+++ b/ui/e2e/messaging_crud.spec.ts
@@ -54,8 +54,15 @@ test.describe('Core Messaging CRUD (Issue #4)', () => {
     await expect(deleteBtn).toBeVisible({ timeout: 5000 });
     await deleteBtn.click({ force: true });
 
-    // Message should disappear
-    await expect(msgLocator).not.toBeVisible({ timeout: 10000 });
+    // Confirm deletion in the dialog
+    const deleteForEveryoneBtn = page.getByRole('button', { name: 'Delete for Everyone' });
+    await expect(deleteForEveryoneBtn).toBeVisible({ timeout: 5000 });
+    await deleteForEveryoneBtn.click();
+
+    // Message should show tombstone instead of original content
+    await expect(page.getByText('This message was deleted').first()).toBeVisible({ timeout: 10000 });
+    // Original text should no longer be visible
+    await expect(page.locator('.message-item').filter({ hasText: uniqueText })).not.toBeVisible({ timeout: 5000 });
   });
 
   test('DELETE /v1/channels/:id/messages/:messageId returns 401 without auth', async ({ page }) => {

--- a/ui/src/components/dashboard/MessageList.tsx
+++ b/ui/src/components/dashboard/MessageList.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import { FormattedMessage } from '../common/FormattedMessage';
 import { useMessageStore } from '../../stores/messageStore';
 import { useAuthStore } from '../../stores/authStore';
-import { MessageCircle, Edit2, SmilePlus, Pin, Bookmark, Quote, Send, Trash2 } from 'lucide-react';
+import { MessageCircle, Edit2, SmilePlus, Pin, Bookmark, Quote, Send, Trash2, EyeOff, Ban } from 'lucide-react';
 import { PresenceAvatar } from '../common/PresenceAvatar';
 import { EditHistoryModal } from './EditHistoryModal';
 import ForwardModal from './ForwardModal';
@@ -16,7 +16,7 @@ interface MessageListProps {
 }
 
 export const MessageList: React.FC<MessageListProps> = ({ channelId }) => {
-  const { messages, fetchMessages, loadMoreMessages, isLoading, hasMore, setActiveThread, editMessage, deleteMessage, highlightedMessageId, activeThreadId } = useMessageStore();
+  const { messages, fetchMessages, loadMoreMessages, isLoading, hasMore, setActiveThread, editMessage, deleteMessage, hideMessage, highlightedMessageId, activeThreadId } = useMessageStore();
   const { user } = useAuthStore();
   const currentUserId = user?.id;
   
@@ -25,6 +25,7 @@ export const MessageList: React.FC<MessageListProps> = ({ channelId }) => {
   const [historyModalMessageId, setHistoryModalMessageId] = useState<string | null>(null);
   const [activeEmojiPickerMsgId, setActiveEmojiPickerMsgId] = useState<string | null>(null);
   const [forwardModalMessage, setForwardModalMessage] = useState<Message | null>(null);
+  const [deleteConfirmMsg, setDeleteConfirmMsg] = useState<Message | null>(null);
   
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -197,7 +198,12 @@ export const MessageList: React.FC<MessageListProps> = ({ channelId }) => {
                       </div>
                     )}
                     
-                    {editingMessageId === msg.id ? (
+                    {msg.is_deleted ? (
+                      <div className="flex items-center gap-2 text-gray-500 italic text-sm py-1 opacity-60">
+                        <Ban size={14} />
+                        <span>This message was deleted</span>
+                      </div>
+                    ) : editingMessageId === msg.id ? (
                       <div className="w-full max-w-lg mt-1 relative z-10 flex flex-col gap-2">
                         <textarea
                           value={editContent}
@@ -298,6 +304,7 @@ export const MessageList: React.FC<MessageListProps> = ({ channelId }) => {
                 </div>
 
                 {/* Hover Actions */}
+                {!msg.is_deleted && (
                 <div className={`absolute top-2 opacity-0 group-hover:opacity-100 transition-opacity flex gap-2 ${isCurrentUser ? 'left-4' : 'right-4'}`}>
                   {isCurrentUser && (
                     <>
@@ -312,9 +319,7 @@ export const MessageList: React.FC<MessageListProps> = ({ channelId }) => {
                         <Edit2 size={14} />
                       </button>
                       <button
-                        onClick={() => {
-                          if (channelId) deleteMessage(channelId, msg.id);
-                        }}
+                        onClick={() => setDeleteConfirmMsg(msg)}
                         className="p-1.5 rounded-lg bg-[#2a2a2a] border border-white/5 text-gray-400 hover:text-red-400 hover:bg-[#333] transition-all shadow-lg flex items-center gap-1.5"
                         title="Delete message"
                       >
@@ -364,14 +369,26 @@ export const MessageList: React.FC<MessageListProps> = ({ channelId }) => {
                     <span className="text-xs font-medium pr-1">Reply</span>
                   </button>
 
-                  <button 
+                  <button
                     onClick={() => setForwardModalMessage(msg)}
                     className="p-1.5 rounded-lg bg-[#2a2a2a] border border-white/5 text-gray-400 hover:text-white hover:bg-[#333] transition-all shadow-lg flex items-center gap-1.5"
                     title="Forward message"
                   >
                     <Send size={14} />
                   </button>
+
+                  {/* Hide for me (non-owner) */}
+                  {!isCurrentUser && (
+                    <button
+                      onClick={() => { if (channelId) hideMessage(channelId, msg.id); }}
+                      className="p-1.5 rounded-lg bg-[#2a2a2a] border border-white/5 text-gray-400 hover:text-red-400 hover:bg-[#333] transition-all shadow-lg flex items-center gap-1.5"
+                      title="Hide for me"
+                    >
+                      <EyeOff size={14} />
+                    </button>
+                  )}
                 </div>
+                )}
 
               </motion.div>
             );
@@ -391,11 +408,57 @@ export const MessageList: React.FC<MessageListProps> = ({ channelId }) => {
       )}
 
       {forwardModalMessage && (
-        <ForwardModal 
+        <ForwardModal
           isOpen={!!forwardModalMessage}
           onClose={() => setForwardModalMessage(null)}
           message={forwardModalMessage}
         />
+      )}
+
+      {/* Delete Confirmation Dialog */}
+      {deleteConfirmMsg && channelId && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setDeleteConfirmMsg(null)}>
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            className="bg-[#1a1a2e] border border-white/10 rounded-2xl p-6 max-w-sm w-full mx-4 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-white font-semibold text-lg mb-2">Delete Message</h3>
+            <p className="text-gray-400 text-sm mb-1">Are you sure you want to delete this message?</p>
+            <div className="bg-white/5 rounded-lg p-3 mb-4 text-sm text-gray-300 truncate">
+              {deleteConfirmMsg.content_md.slice(0, 100)}{deleteConfirmMsg.content_md.length > 100 ? '...' : ''}
+            </div>
+            <div className="flex flex-col gap-2">
+              <button
+                onClick={async () => {
+                  await deleteMessage(channelId, deleteConfirmMsg.id);
+                  setDeleteConfirmMsg(null);
+                }}
+                className="w-full py-2 px-4 bg-red-600 hover:bg-red-500 text-white rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2"
+              >
+                <Trash2 size={14} />
+                Delete for Everyone
+              </button>
+              <button
+                onClick={async () => {
+                  await hideMessage(channelId, deleteConfirmMsg.id);
+                  setDeleteConfirmMsg(null);
+                }}
+                className="w-full py-2 px-4 bg-white/10 hover:bg-white/15 text-gray-300 rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2"
+              >
+                <EyeOff size={14} />
+                Delete for Me
+              </button>
+              <button
+                onClick={() => setDeleteConfirmMsg(null)}
+                className="w-full py-2 px-4 text-gray-500 hover:text-white text-sm transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </motion.div>
+        </div>
       )}
     </div>
   );

--- a/ui/src/components/dashboard/MessageList.tsx
+++ b/ui/src/components/dashboard/MessageList.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { FormattedMessage } from '../common/FormattedMessage';
 import { useMessageStore } from '../../stores/messageStore';
 import { useAuthStore } from '../../stores/authStore';
-import { MessageCircle, Edit2, SmilePlus, Pin, Bookmark, Quote, Send, Trash2, ArrowDown, Shield, EyeOff, Ban } from 'lucide-react';
+import { MessageCircle, Edit2, SmilePlus, Pin, Bookmark, Quote, Send, Trash2, EyeOff, Ban, ArrowDown, Shield } from 'lucide-react';
 import { PresenceAvatar } from '../common/PresenceAvatar';
 import { EditHistoryModal } from './EditHistoryModal';
 import ForwardModal from './ForwardModal';

--- a/ui/src/stores/messageStore.ts
+++ b/ui/src/stores/messageStore.ts
@@ -33,6 +33,7 @@ export interface Message {
   user_reactions?: string[];
   is_pinned?: boolean;
   is_bookmarked?: boolean;
+  is_deleted?: boolean;
   forward_source_id?: string;
   forward_source_username?: string;
   created_at: string;
@@ -105,6 +106,7 @@ interface MessageState {
 
   editMessage: (channelId: string, messageId: string, contentMd: string) => Promise<void>;
   deleteMessage: (channelId: string, messageId: string) => Promise<void>;
+  hideMessage: (channelId: string, messageId: string) => Promise<void>;
   getMessageHistory: (channelId: string, messageId: string) => Promise<MessageEdit[]>;
   toggleReaction: (channelId: string, messageId: string, emoji: string) => Promise<void>;
   togglePin: (channelId: string, messageId: string) => Promise<void>;
@@ -578,10 +580,38 @@ export const useMessageStore = create<MessageState>((set, get) => ({
 
       if (!response.ok) throw new Error('Failed to delete message');
 
+      // Show tombstone instead of removing
       set((state) => ({
-        messages: state.messages.filter(m => m.id !== messageId),
-        threadMessages: state.threadMessages.filter(m => m.id !== messageId)
+        messages: state.messages.map(m =>
+          m.id === messageId ? { ...m, is_deleted: true, content_md: '', content_html: '' } : m
+        ),
+        threadMessages: state.threadMessages.map(m =>
+          m.id === messageId ? { ...m, is_deleted: true, content_md: '', content_html: '' } : m
+        ),
       }));
+    } catch (err) {
+      set({ error: (err as Error).message });
+      throw err;
+    }
+  },
+
+  hideMessage: async (channelId, messageId) => {
+    // Optimistic: remove from view immediately
+    const prevMessages = get().messages;
+    set((state) => ({
+      messages: state.messages.filter(m => m.id !== messageId),
+    }));
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/channels/${channelId}/messages/${messageId}/hide`, {
+        method: 'POST',
+        headers: authHeaders(),
+      });
+      if (!response.ok) {
+        // Revert on error
+        set({ messages: prevMessages });
+        throw new Error('Failed to hide message');
+      }
     } catch (err) {
       set({ error: (err as Error).message });
       throw err;


### PR DESCRIPTION
## Summary
- **Backend**: Soft delete (sets `deleted_at` instead of hard delete), `user_hidden_messages` table for "Delete for Me", new `POST /messages/:id/hide` endpoint, hidden/deleted message filtering in queries
- **Frontend**: Tombstone placeholder for deleted messages, delete confirmation dialog with "Delete for Everyone" / "Delete for Me" options, "Hide for me" button on other users' messages, optimistic hide with revert on error

## Test plan
- [ ] Verify "Delete for Everyone" soft-deletes message and shows tombstone to all users
- [ ] Verify "Delete for Me" hides message only for the acting user
- [ ] Verify confirmation dialog shows before delete
- [ ] Verify hover actions are hidden on deleted messages
- [ ] Verify Go and TypeScript compile cleanly
- [ ] Verify existing E2E tests still pass

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)