### PR TITLE
feat(#50): Keyboard shortcuts & accessibility improvements

### DIFF
--- a/ui/src/components/common/ShortcutsModal.tsx
+++ b/ui/src/components/common/ShortcutsModal.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, Keyboard } from 'lucide-react';
+import { getRegisteredShortcuts } from '../../hooks/useKeyboardShortcuts';
+
+interface ShortcutsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const ShortcutsModal: React.FC<ShortcutsModalProps> = ({ isOpen, onClose }) => {
+  const shortcuts = getRegisteredShortcuts();
+
+  // Group by category
+  const grouped = shortcuts.reduce<Record<string, typeof shortcuts>>((acc, s) => {
+    if (!acc[s.category]) acc[s.category] = [];
+    acc[s.category].push(s);
+    return acc;
+  }, {});
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleEsc, true);
+    return () => window.removeEventListener('keydown', handleEsc, true);
+  }, [isOpen, onClose]);
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          onClick={onClose}
+        >
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 20 }}
+            transition={{ duration: 0.15 }}
+            onClick={(e) => e.stopPropagation()}
+            className="w-full max-w-lg bg-[#111] border border-white/10 rounded-2xl shadow-2xl overflow-hidden"
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between px-6 py-4 border-b border-white/5 bg-white/[0.02]">
+              <h2 className="text-lg font-semibold text-white flex items-center gap-2">
+                <Keyboard size={20} className="text-blue-400" />
+                Keyboard Shortcuts
+              </h2>
+              <button
+                onClick={onClose}
+                className="p-1.5 rounded-lg hover:bg-white/10 text-gray-400 hover:text-white transition-colors"
+                title="Close"
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            {/* Shortcuts List */}
+            <div className="px-6 py-4 max-h-[60vh] overflow-y-auto space-y-6">
+              {Object.entries(grouped).map(([category, items]) => (
+                <div key={category}>
+                  <h3 className="text-[11px] font-bold uppercase tracking-wider text-gray-500 mb-3">
+                    {category}
+                  </h3>
+                  <div className="space-y-2">
+                    {items.map((shortcut) => (
+                      <div
+                        key={shortcut.key}
+                        className="flex items-center justify-between py-1.5"
+                      >
+                        <span className="text-sm text-gray-300">{shortcut.description}</span>
+                        <kbd className="px-2 py-1 text-xs font-mono bg-white/5 border border-white/10 rounded-md text-gray-400 min-w-[40px] text-center">
+                          {shortcut.display}
+                        </kbd>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+
+              {shortcuts.length === 0 && (
+                <div className="text-center text-gray-500 text-sm py-8">
+                  No shortcuts registered
+                </div>
+              )}
+            </div>
+
+            {/* Footer */}
+            <div className="px-6 py-3 border-t border-white/5 bg-white/[0.02]">
+              <p className="text-[11px] text-gray-500 text-center">
+                Press <kbd className="px-1.5 py-0.5 bg-white/5 border border-white/10 rounded text-gray-400 font-mono">?</kbd> to toggle this modal
+              </p>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/ui/src/components/dashboard/MessageList.tsx
+++ b/ui/src/components/dashboard/MessageList.tsx
@@ -107,10 +107,13 @@ export const MessageList: React.FC<MessageListProps> = ({ channelId }) => {
   }
 
   return (
-    <div 
+    <div
       ref={scrollContainerRef}
       onScroll={handleScroll}
       className="flex-1 overflow-y-auto px-6 pt-4 flex flex-col custom-scrollbar"
+      role="log"
+      aria-label="Message list"
+      aria-live="polite"
     >
       <div className="flex-1 flex flex-col max-w-4xl mx-auto w-full min-h-0">
         

--- a/ui/src/components/layout/DashboardLayout.tsx
+++ b/ui/src/components/layout/DashboardLayout.tsx
@@ -1,20 +1,100 @@
-import React from 'react';
-import { Outlet } from 'react-router-dom';
+import React, { useState, useMemo, useCallback } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 import { useWebSocket } from '../../hooks/useWebSocket';
+import { useKeyboardShortcuts, type Shortcut } from '../../hooks/useKeyboardShortcuts';
+import { ShortcutsModal } from '../common/ShortcutsModal';
+import { useMessageStore } from '../../stores/messageStore';
 
 export const DashboardLayout: React.FC = () => {
   useWebSocket();
+  const navigate = useNavigate();
+  const [showShortcuts, setShowShortcuts] = useState(false);
+  const [sidebarVisible, setSidebarVisible] = useState(true);
+  const { channels, activeChannel, setActiveChannel, fetchMessages } = useMessageStore();
+
+  const navigateChannel = useCallback((direction: -1 | 1) => {
+    if (channels.length === 0) return;
+    const currentIdx = channels.findIndex(c => c.id === activeChannel?.id);
+    const nextIdx = currentIdx === -1
+      ? 0
+      : (currentIdx + direction + channels.length) % channels.length;
+    const next = channels[nextIdx];
+    setActiveChannel(next);
+    fetchMessages(next.id);
+    navigate('/dashboard');
+  }, [channels, activeChannel, setActiveChannel, fetchMessages, navigate]);
+
+  const shortcuts: Shortcut[] = useMemo(() => [
+    {
+      key: '?',
+      description: 'Show keyboard shortcuts',
+      category: 'General',
+      action: () => setShowShortcuts(prev => !prev),
+    },
+    {
+      key: 'k',
+      meta: true,
+      description: 'Quick search',
+      category: 'Navigation',
+      action: () => {
+        // Focus search input if it exists
+        const searchInput = document.querySelector('[data-testid="search-input"]') as HTMLInputElement;
+        if (searchInput) searchInput.focus();
+      },
+    },
+    {
+      key: '\\',
+      meta: true,
+      shift: true,
+      description: 'Toggle sidebar',
+      category: 'Navigation',
+      action: () => setSidebarVisible(prev => !prev),
+    },
+    {
+      key: 'ArrowUp',
+      alt: true,
+      description: 'Previous channel',
+      category: 'Navigation',
+      action: () => navigateChannel(-1),
+    },
+    {
+      key: 'ArrowDown',
+      alt: true,
+      description: 'Next channel',
+      category: 'Navigation',
+      action: () => navigateChannel(1),
+    },
+    {
+      key: 'Escape',
+      description: 'Close panel / cancel',
+      category: 'General',
+      action: () => {
+        const { setActiveThread } = useMessageStore.getState();
+        setActiveThread(null);
+      },
+    },
+  ], [navigateChannel]);
+
+  useKeyboardShortcuts(shortcuts);
 
   return (
     <div className="h-screen w-full bg-[#030712] flex overflow-hidden">
-      <Sidebar />
-      <main className="flex-1 h-full overflow-hidden relative">
+      {/* Skip to content link for keyboard/screen reader users */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-[200] focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:bg-blue-600 focus:text-white focus:rounded-lg focus:text-sm"
+      >
+        Skip to content
+      </a>
+      {sidebarVisible && <Sidebar />}
+      <main id="main-content" className="flex-1 h-full overflow-hidden relative" role="main" aria-label="Main content">
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-blue-500/5 rounded-full blur-[120px] pointer-events-none" />
         <div className="relative z-10 h-full w-full">
           <Outlet />
         </div>
       </main>
+      <ShortcutsModal isOpen={showShortcuts} onClose={() => setShowShortcuts(false)} />
     </div>
   );
 };

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -35,17 +35,20 @@ import CreateChannelModal from '../dashboard/CreateChannelModal';
 import BrowseChannelsModal from '../dashboard/BrowseChannelsModal';
 import CreateOrgModal from '../dashboard/CreateOrgModal';
 
-const NavItem = ({ icon: Icon, text, active, onClick }: { icon: React.ElementType, text: string, active?: boolean, onClick?: () => void }) => (
+const NavItem = ({ icon: Icon, text, active, onClick, ariaLabel }: { icon: React.ElementType, text: string, active?: boolean, onClick?: () => void, ariaLabel?: string }) => (
   <motion.button
     whileHover={{ x: 4 }}
     whileTap={{ scale: 0.98 }}
     animate={{ backgroundColor: active ? 'rgba(255,255,255,0.1)' : 'rgba(255,255,255,0)' }}
     onClick={onClick}
-    className={`w-full h-10 px-3 rounded-xl flex items-center gap-3 transition-colors hover:bg-white/5 ${
+    aria-label={ariaLabel || text}
+    aria-current={active ? 'page' : undefined}
+    role="menuitem"
+    className={`w-full h-10 px-3 rounded-xl flex items-center gap-3 transition-colors hover:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 focus-visible:ring-offset-1 focus-visible:ring-offset-[#0d0d0d] ${
       active ? 'text-white' : 'text-gray-400 hover:text-white'
     }`}
   >
-    <Icon size={18} className={active ? 'text-blue-400' : ''} />
+    <Icon size={18} className={active ? 'text-blue-400' : ''} aria-hidden="true" />
     <span className="text-[14px] font-medium truncate">{text}</span>
   </motion.button>
 );
@@ -283,7 +286,7 @@ const handleNewDM = async (userId: string, _username: string) => {
   const displayOrgName = orgName || 'Nox Workspace';
 
   return (
-    <div className="w-64 h-full bg-[#0d0d0d] border-r border-white/5 flex flex-col pt-4 pb-4">
+    <nav className="w-64 h-full bg-[#0d0d0d] border-r border-white/5 flex flex-col pt-4 pb-4" role="navigation" aria-label="Sidebar navigation">
 
       {/* Org Header with Switcher */}
       <div className="relative px-2 mb-6">
@@ -356,7 +359,7 @@ const handleNewDM = async (userId: string, _username: string) => {
       </div>
 
       {/* Main Navigation */}
-      <div className="flex-1 overflow-y-auto px-3 space-y-6">
+      <div className="flex-1 overflow-y-auto px-3 space-y-6" role="menu">
 
         <div className="space-y-1">
           <NavItem icon={Search} text="Search" />
@@ -867,6 +870,6 @@ const handleNewDM = async (userId: string, _username: string) => {
           </motion.div>
         )}
       </AnimatePresence>
-    </div>
+    </nav>
   );
 };

--- a/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,117 @@
+import { useEffect, useCallback, useRef } from 'react';
+
+export interface Shortcut {
+  key: string;
+  ctrl?: boolean;
+  meta?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  description: string;
+  category: string;
+  action: () => void;
+}
+
+type ShortcutHandler = () => void;
+
+interface ShortcutRegistration {
+  key: string;
+  modifiers: { ctrl?: boolean; meta?: boolean; shift?: boolean; alt?: boolean };
+  handler: ShortcutHandler;
+  description: string;
+  category: string;
+}
+
+const registrations = new Map<string, ShortcutRegistration>();
+
+function makeKey(key: string, mods: { ctrl?: boolean; meta?: boolean; shift?: boolean; alt?: boolean }): string {
+  const parts: string[] = [];
+  if (mods.ctrl || mods.meta) parts.push('mod');
+  if (mods.shift) parts.push('shift');
+  if (mods.alt) parts.push('alt');
+  parts.push(key.toLowerCase());
+  return parts.join('+');
+}
+
+export function getRegisteredShortcuts(): { key: string; description: string; category: string; display: string }[] {
+  const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+  const modSymbol = isMac ? '\u2318' : 'Ctrl';
+  const shiftSymbol = isMac ? '\u21E7' : 'Shift';
+  const altSymbol = isMac ? '\u2325' : 'Alt';
+
+  return Array.from(registrations.values()).map(reg => {
+    const parts: string[] = [];
+    if (reg.modifiers.ctrl || reg.modifiers.meta) parts.push(modSymbol);
+    if (reg.modifiers.shift) parts.push(shiftSymbol);
+    if (reg.modifiers.alt) parts.push(altSymbol);
+    parts.push(reg.key.length === 1 ? reg.key.toUpperCase() : reg.key);
+    return {
+      key: makeKey(reg.key, reg.modifiers),
+      description: reg.description,
+      category: reg.category,
+      display: parts.join(isMac ? '' : '+'),
+    };
+  });
+}
+
+export function useKeyboardShortcuts(shortcuts: Shortcut[]) {
+  const shortcutsRef = useRef(shortcuts);
+
+  useEffect(() => {
+    shortcutsRef.current = shortcuts;
+  });
+
+  useEffect(() => {
+    const ids: string[] = [];
+    for (const s of shortcutsRef.current) {
+      const mods = { ctrl: s.ctrl, meta: s.meta, shift: s.shift, alt: s.alt };
+      const id = makeKey(s.key, mods);
+      registrations.set(id, {
+        key: s.key,
+        modifiers: mods,
+        handler: s.action,
+        description: s.description,
+        category: s.category,
+      });
+      ids.push(id);
+    }
+    return () => {
+      for (const id of ids) {
+        registrations.delete(id);
+      }
+    };
+  }, []);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    // Don't intercept when typing in inputs/textareas (unless it's a mod shortcut)
+    const target = e.target as HTMLElement;
+    const isInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
+    const hasMod = e.metaKey || e.ctrlKey;
+
+    // For single-key shortcuts (like '?'), skip if typing in an input
+    if (isInput && !hasMod) return;
+
+    const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+    const modPressed = isMac ? e.metaKey : e.ctrlKey;
+
+    for (const reg of registrations.values()) {
+      const wantsMod = reg.modifiers.ctrl || reg.modifiers.meta;
+      const wantsShift = !!reg.modifiers.shift;
+      const wantsAlt = !!reg.modifiers.alt;
+
+      if (e.key.toLowerCase() === reg.key.toLowerCase() &&
+          !!modPressed === !!wantsMod &&
+          e.shiftKey === wantsShift &&
+          e.altKey === wantsAlt) {
+        e.preventDefault();
+        e.stopPropagation();
+        reg.handler();
+        return;
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => window.removeEventListener('keydown', handleKeyDown, true);
+  }, [handleKeyDown]);
+}


### PR DESCRIPTION
## Summary
- Global keyboard shortcut system with `useKeyboardShortcuts` hook and shortcut registry
- Shortcuts help modal (press `?` to toggle) showing all registered shortcuts grouped by category
- `Cmd/Ctrl+Shift+\` to toggle sidebar, `Alt+Up/Down` to navigate channels, `Escape` to close thread panel
- Skip-to-content link, ARIA roles/labels, focus-visible rings, and `aria-live` on message list

## Test plan
- [ ] Press `?` → shortcuts modal opens/closes
- [ ] Press `Cmd+Shift+\` → sidebar toggles
- [ ] Press `Alt+Down` → next channel selected
- [ ] Tab navigation works through sidebar items with visible focus rings
- [ ] Screen reader announces new messages in message list

🤖 Generated with [Claude Code](https://claude.com/claude-code)