### PR TITLE
feat(#69): Debounced read receipts & unread counts

### DIFF
--- a/services/bifrost/cmd/gateway/main.go
+++ b/services/bifrost/cmd/gateway/main.go
@@ -201,6 +201,7 @@ func main() {
 			// Channel CRUD Routes
 			authenticated.POST("/channels", messagingHandler.CreateChannel)
 			authenticated.GET("/channels", messagingHandler.GetChannels)
+			authenticated.GET("/channels/unread-counts", messagingHandler.GetUnreadCounts)
 			authenticated.GET("/channels/browse", messagingHandler.BrowseChannels)
 			authenticated.GET("/channels/joined", messagingHandler.GetJoinedChannels)
 			authenticated.GET("/channels/:id", messagingHandler.GetChannel)

--- a/services/bifrost/internal/messaging/handler.go
+++ b/services/bifrost/internal/messaging/handler.go
@@ -488,6 +488,25 @@ func (h *MessagingHandler) GetChannelReadReceipts(c *gin.Context) {
 	c.JSON(http.StatusOK, reads)
 }
 
+func (h *MessagingHandler) GetUnreadCounts(c *gin.Context) {
+	_, userID := getAuthInfo(c)
+	if userID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "X-User-ID required"})
+		return
+	}
+
+	counts, err := h.service.GetUnreadCounts(c.Request.Context(), userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if counts == nil {
+		counts = []UnreadCount{}
+	}
+	c.JSON(http.StatusOK, counts)
+}
+
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,

--- a/services/bifrost/internal/messaging/models.go
+++ b/services/bifrost/internal/messaging/models.go
@@ -124,6 +124,12 @@ type ConvertDMRequest struct {
 	IsPrivate *bool  `json:"is_private"`
 }
 
+// UnreadCount represents the number of unread messages for a channel.
+type UnreadCount struct {
+	ChannelID string `json:"channel_id"`
+	Count     int    `json:"count"`
+}
+
 // BrowsableChannel extends Channel with member count and join status for the browse endpoint (Issue #121).
 type BrowsableChannel struct {
 	ID          string     `json:"id"`

--- a/services/bifrost/internal/messaging/service.go
+++ b/services/bifrost/internal/messaging/service.go
@@ -569,6 +569,38 @@ func (s *MessagingService) GetChannelReadReceipts(ctx context.Context, channelID
 	return reads, nil
 }
 
+// GetUnreadCounts returns the number of unread messages per channel for the given user.
+// A channel is included if the user has a channel_reads entry; messages created after
+// the last_read_message's created_at are counted as unread.
+func (s *MessagingService) GetUnreadCounts(ctx context.Context, userID string) ([]UnreadCount, error) {
+	query := `
+		SELECT cr.channel_id,
+			COUNT(m.id)::int AS unread_count
+		FROM channel_reads cr
+		JOIN messages last_msg ON last_msg.id = cr.last_read_message_id
+		LEFT JOIN messages m ON m.channel_id = cr.channel_id
+			AND m.created_at > last_msg.created_at
+			AND m.parent_id IS NULL
+		WHERE cr.user_id = $1
+		GROUP BY cr.channel_id
+	`
+	rows, err := s.db.Pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var counts []UnreadCount
+	for rows.Next() {
+		var uc UnreadCount
+		if err := rows.Scan(&uc.ChannelID, &uc.Count); err != nil {
+			return nil, err
+		}
+		counts = append(counts, uc)
+	}
+	return counts, nil
+}
+
 // ---------- Channel Members (Private Channel ACL - Issue #120) ----------
 
 func (s *MessagingService) IsChannelMember(ctx context.Context, channelID, userID string) (bool, error) {

--- a/ui/src/components/dashboard/MessageList.tsx
+++ b/ui/src/components/dashboard/MessageList.tsx
@@ -85,7 +85,6 @@ export const MessageList: React.FC<MessageListProps> = ({ channelId }) => {
     if (isFetchingOlder && scrollContainerRef.current) {
       const container = scrollContainerRef.current;
       container.scrollTop = container.scrollHeight - previousScrollHeight;
-      // eslint-disable-next-line
       setIsFetchingOlder(false);
     }
   }, [messages, isFetchingOlder, previousScrollHeight]);

--- a/ui/src/components/dashboard/MessageList.tsx
+++ b/ui/src/components/dashboard/MessageList.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useRef, useLayoutEffect, useState } from 'react';
+import React, { useEffect, useRef, useLayoutEffect, useState, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import { FormattedMessage } from '../common/FormattedMessage';
 import { useMessageStore } from '../../stores/messageStore';
 import { useAuthStore } from '../../stores/authStore';
+import { useReadStore } from '../../stores/readStore';
 import { MessageCircle, Edit2, SmilePlus, Pin, Bookmark, Quote, Send, Trash2 } from 'lucide-react';
 import { PresenceAvatar } from '../common/PresenceAvatar';
 import { EditHistoryModal } from './EditHistoryModal';
@@ -18,14 +19,17 @@ interface MessageListProps {
 export const MessageList: React.FC<MessageListProps> = ({ channelId }) => {
   const { messages, fetchMessages, loadMoreMessages, isLoading, hasMore, setActiveThread, editMessage, deleteMessage, highlightedMessageId, activeThreadId } = useMessageStore();
   const { user } = useAuthStore();
+  const { markChannelRead, unreadCounts } = useReadStore();
   const currentUserId = user?.id;
-  
+
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editContent, setEditContent] = useState('');
   const [historyModalMessageId, setHistoryModalMessageId] = useState<string | null>(null);
   const [activeEmojiPickerMsgId, setActiveEmojiPickerMsgId] = useState<string | null>(null);
   const [forwardModalMessage, setForwardModalMessage] = useState<Message | null>(null);
-  
+  // Track the first unread message ID for the "New messages" separator
+  const [firstUnreadMsgId, setFirstUnreadMsgId] = useState<string | null>(null);
+
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [previousScrollHeight, setPreviousScrollHeight] = useState(0);
@@ -36,6 +40,34 @@ export const MessageList: React.FC<MessageListProps> = ({ channelId }) => {
       fetchMessages(channelId);
     }
   }, [channelId, fetchMessages]);
+
+  // Compute the first unread message when messages or unread counts change
+  useEffect(() => {
+    if (!channelId || messages.length === 0) {
+      setFirstUnreadMsgId(null);
+      return;
+    }
+    const unread = unreadCounts[channelId] || 0;
+    if (unread > 0 && unread <= messages.length) {
+      // The first unread message is at index (messages.length - unread)
+      setFirstUnreadMsgId(messages[messages.length - unread].id);
+    } else {
+      setFirstUnreadMsgId(null);
+    }
+  // Only recompute when channel changes or initial load, not on every message
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [channelId]);
+
+  // Mark channel as read when user scrolls to bottom
+  const checkScrollBottom = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container || !channelId || messages.length === 0) return;
+    const isAtBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 50;
+    if (isAtBottom) {
+      const lastMsg = messages[messages.length - 1];
+      markChannelRead(channelId, lastMsg.id);
+    }
+  }, [channelId, messages, markChannelRead]);
 
 
 
@@ -58,6 +90,16 @@ export const MessageList: React.FC<MessageListProps> = ({ channelId }) => {
     }
   }, [messages, isFetchingOlder, previousScrollHeight]);
 
+  // Mark as read when initially scrolled to bottom after load
+  useEffect(() => {
+    if (!isLoading && messages.length > 0 && !isFetchingOlder) {
+      // Use a small timeout to let the layout settle
+      const timer = setTimeout(checkScrollBottom, 100);
+      return () => clearTimeout(timer);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading, messages.length, channelId]);
+
   const handleScroll = async (e: React.UIEvent<HTMLDivElement>) => {
     const target = e.currentTarget;
     if (target.scrollTop === 0 && hasMore && !isLoading && messages.length > 0 && channelId) {
@@ -66,6 +108,8 @@ export const MessageList: React.FC<MessageListProps> = ({ channelId }) => {
       const oldestMessage = messages[0];
       await loadMoreMessages(channelId, oldestMessage.created_at);
     }
+    // Check if scrolled to bottom to mark as read
+    checkScrollBottom();
   };
 
   const handleSaveEdit = async (msgId: string) => {
@@ -124,10 +168,18 @@ export const MessageList: React.FC<MessageListProps> = ({ channelId }) => {
           {messages.map((msg: Message, i) => {
             const isConsecutive = i > 0 && messages[i - 1].user_id === msg.user_id;
             const isCurrentUser = msg.user_id === currentUserId;
+            const showNewMessagesSeparator = firstUnreadMsgId === msg.id;
 
             return (
-              <motion.div 
-                key={msg.id}
+              <React.Fragment key={msg.id}>
+                {showNewMessagesSeparator && (
+                  <div className="flex items-center gap-3 my-4" data-testid="new-messages-separator">
+                    <div className="flex-1 h-px bg-red-500/50" />
+                    <span className="text-xs font-semibold text-red-400 uppercase tracking-wider shrink-0">New messages</span>
+                    <div className="flex-1 h-px bg-red-500/50" />
+                  </div>
+                )}
+              <motion.div
                 data-message-id={msg.id}
                 data-user-id={msg.user_id}
                 initial={{ opacity: 0, y: 10 }}
@@ -374,6 +426,7 @@ export const MessageList: React.FC<MessageListProps> = ({ channelId }) => {
                 </div>
 
               </motion.div>
+              </React.Fragment>
             );
           })}
         </div>

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -7,6 +7,7 @@ import { usePresenceStore } from '../../stores/presenceStore';
 import { useNotificationStore, type Notification as NotifType } from '../../stores/notificationStore';
 import { useFriendStore } from '../../stores/friendStore';
 import { useCategoryStore, type CategoryWithChannels } from '../../stores/categoryStore';
+import { useReadStore } from '../../stores/readStore';
 import { PresenceAvatar } from '../common/PresenceAvatar';
 import {
   Hash,
@@ -35,7 +36,7 @@ import CreateChannelModal from '../dashboard/CreateChannelModal';
 import BrowseChannelsModal from '../dashboard/BrowseChannelsModal';
 import CreateOrgModal from '../dashboard/CreateOrgModal';
 
-const NavItem = ({ icon: Icon, text, active, onClick }: { icon: React.ElementType, text: string, active?: boolean, onClick?: () => void }) => (
+const NavItem = ({ icon: Icon, text, active, onClick, unreadCount }: { icon: React.ElementType, text: string, active?: boolean, onClick?: () => void, unreadCount?: number }) => (
   <motion.button
     whileHover={{ x: 4 }}
     whileTap={{ scale: 0.98 }}
@@ -46,7 +47,12 @@ const NavItem = ({ icon: Icon, text, active, onClick }: { icon: React.ElementTyp
     }`}
   >
     <Icon size={18} className={active ? 'text-blue-400' : ''} />
-    <span className="text-[14px] font-medium truncate">{text}</span>
+    <span className={`text-[14px] truncate flex-1 text-left ${unreadCount && unreadCount > 0 ? 'font-bold text-white' : 'font-medium'}`}>{text}</span>
+    {unreadCount != null && unreadCount > 0 && (
+      <span className="min-w-[20px] h-5 px-1.5 bg-blue-500 rounded-full flex items-center justify-center text-[10px] font-bold text-white shrink-0">
+        {unreadCount > 99 ? '99+' : unreadCount}
+      </span>
+    )}
   </motion.button>
 );
 
@@ -205,6 +211,7 @@ export const Sidebar: React.FC = () => {
   const [editingCategory, setEditingCategory] = useState<string | null>(null);
   const [editCategoryName, setEditCategoryName] = useState('');
   const { categories, collapsedCategories, fetchCategories, createCategory, updateCategory, deleteCategory, toggleCollapse } = useCategoryStore();
+  const { unreadCounts, fetchUnreadCounts, markChannelRead } = useReadStore();
   const [convertDM, setConvertDM] = useState<DMConversation | null>(null);
   const [convertName, setConvertName] = useState('');
   const [convertPrivate, setConvertPrivate] = useState(true);
@@ -225,9 +232,17 @@ export const Sidebar: React.FC = () => {
     fetchDMs();
     fetchNotifications();
     fetchCategories();
-  }, [fetchChannels, fetchJoinedChannels, fetchOrganizations, fetchDMs, fetchNotifications, fetchCategories]);
+    fetchUnreadCounts();
+  }, [fetchChannels, fetchJoinedChannels, fetchOrganizations, fetchDMs, fetchNotifications, fetchCategories, fetchUnreadCounts]);
 
   const handleChannelSelect = (channel: Channel) => {
+    // Mark the previous channel as read before switching
+    if (activeChannel && activeChannel.id !== channel.id) {
+      const msgs = useMessageStore.getState().messages;
+      if (msgs.length > 0) {
+        markChannelRead(activeChannel.id, msgs[msgs.length - 1].id);
+      }
+    }
     setActiveChannel(channel);
     navigate('/dashboard');
   };
@@ -627,6 +642,7 @@ const handleNewDM = async (userId: string, _username: string) => {
                                 text={channel.name}
                                 active={currentChannelId === channel.id}
                                 onClick={() => handleChannelSelect(channel as Channel)}
+                                unreadCount={unreadCounts[channel.id]}
                               />
                             </div>
                           );
@@ -664,6 +680,7 @@ const handleNewDM = async (userId: string, _username: string) => {
                             text={channel.name}
                             active={currentChannelId === channel.id}
                             onClick={() => handleChannelSelect(channel)}
+                            unreadCount={unreadCounts[channel.id]}
                           />
                         </div>
                       );

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useMessageStore } from '../stores/messageStore';
 import { useAuthStore } from '../stores/authStore';
 import { useNotificationStore } from '../stores/notificationStore';
+import { useReadStore } from '../stores/readStore';
 
 const WS_BASE_URL = 'ws://localhost:8080/ws';
 let globalWs: WebSocket | null = null;
@@ -72,6 +73,9 @@ export function useWebSocket() {
               if (payload.user_id !== user?.id) {
                 store.onTypingIndicator(payload.channel_id, payload.username, payload.is_typing);
               }
+              break;
+            case 'READ_RECEIPT_UPDATED':
+              useReadStore.getState().onReadReceiptUpdated(payload);
               break;
             case 'NOTIFICATION_NEW':
               useNotificationStore.getState().addNotification(payload);

--- a/ui/src/stores/readStore.ts
+++ b/ui/src/stores/readStore.ts
@@ -1,0 +1,103 @@
+import { create } from 'zustand';
+
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem('nox_token') || '';
+  return { Authorization: `Bearer ${token}` };
+}
+
+const API_BASE = 'http://localhost:8080/v1';
+
+interface UnreadCountEntry {
+  channel_id: string;
+  count: number;
+}
+
+interface ReadState {
+  unreadCounts: Record<string, number>;
+  lastReadTimestamps: Record<string, string>;
+  fetchUnreadCounts: () => Promise<void>;
+  markChannelRead: (channelId: string, messageId: string) => void;
+  setUnread: (channelId: string, count: number) => void;
+  decrementUnread: (channelId: string) => void;
+  onReadReceiptUpdated: (data: { channel_id: string; user_id: string; last_read_message_id: string }) => void;
+}
+
+// Debounce timers keyed by channelId
+const debounceTimers: Record<string, ReturnType<typeof setTimeout>> = {};
+
+export const useReadStore = create<ReadState>((set, get) => ({
+  unreadCounts: {},
+  lastReadTimestamps: {},
+
+  fetchUnreadCounts: async () => {
+    try {
+      const res = await fetch(`${API_BASE}/channels/unread-counts`, {
+        headers: authHeaders(),
+      });
+      if (res.ok) {
+        const data: UnreadCountEntry[] = await res.json();
+        const counts: Record<string, number> = {};
+        for (const entry of data) {
+          counts[entry.channel_id] = entry.count;
+        }
+        set({ unreadCounts: counts });
+      }
+    } catch {
+      // ignore fetch errors
+    }
+  },
+
+  markChannelRead: (channelId: string, messageId: string) => {
+    // Optimistic update: set unread to 0 immediately
+    set((state) => ({
+      unreadCounts: { ...state.unreadCounts, [channelId]: 0 },
+    }));
+
+    // Debounce the actual API call by 2 seconds
+    if (debounceTimers[channelId]) {
+      clearTimeout(debounceTimers[channelId]);
+    }
+
+    debounceTimers[channelId] = setTimeout(async () => {
+      try {
+        await fetch(`${API_BASE}/channels/${channelId}/read`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', ...authHeaders() },
+          body: JSON.stringify({ message_id: messageId }),
+        });
+      } catch {
+        // If the API call fails, refetch to get accurate counts
+        get().fetchUnreadCounts();
+      }
+    }, 2000);
+  },
+
+  setUnread: (channelId: string, count: number) => {
+    set((state) => ({
+      unreadCounts: { ...state.unreadCounts, [channelId]: count },
+    }));
+  },
+
+  decrementUnread: (channelId: string) => {
+    set((state) => {
+      const current = state.unreadCounts[channelId] || 0;
+      return {
+        unreadCounts: {
+          ...state.unreadCounts,
+          [channelId]: Math.max(0, current - 1),
+        },
+      };
+    });
+  },
+
+  onReadReceiptUpdated: (data: { channel_id: string; user_id: string; last_read_message_id: string }) => {
+    // When we receive a read receipt update for the current user,
+    // set that channel's unread count to 0
+    const currentUser = JSON.parse(localStorage.getItem('nox_user') || '{}');
+    if (data.user_id === currentUser.id) {
+      set((state) => ({
+        unreadCounts: { ...state.unreadCounts, [data.channel_id]: 0 },
+      }));
+    }
+  },
+}));


### PR DESCRIPTION
## Summary
- Unread message count per channel displayed in sidebar with badge
- Bold channel names when unread messages exist
- Debounced read status updates (batched while scrolling)
- "New messages" separator in message list
- WebSocket handler for READ_RECEIPT_UPDATED events
- New GET /channels/unread-counts endpoint

## Test plan
- [ ] Unread count badges appear on channels with new messages
- [ ] Channel name bolds when unread
- [ ] Switching channels marks previous as read
- [ ] "New messages" separator shows at first unread message
- [ ] Read status updates are debounced (not per-message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)