### PR TITLE
feat(#68): Recursive thread CTEs with nested UI

### DIFF
--- a/services/bifrost/internal/messaging/models.go
+++ b/services/bifrost/internal/messaging/models.go
@@ -34,6 +34,7 @@ type Message struct {
 	UserReactions []string       `json:"user_reactions,omitempty"`
 	IsPinned      bool           `json:"is_pinned"`
 	IsBookmarked  bool           `json:"is_bookmarked"`
+	Depth         int            `json:"depth,omitempty"`
 	CreatedAt     time.Time      `json:"created_at"`
 	UpdatedAt     time.Time      `json:"updated_at"`
 }

--- a/services/bifrost/internal/messaging/service.go
+++ b/services/bifrost/internal/messaging/service.go
@@ -273,17 +273,32 @@ func (s *MessagingService) GetMessagesByChannel(ctx context.Context, channelID s
 
 func (s *MessagingService) GetThreadReplies(ctx context.Context, messageID string, currentUserID string) ([]Message, error) {
 	query := `
-		SELECT m.id, m.channel_id, m.user_id, u.username, m.parent_id, m.reply_to, m.forward_source_id,
+		WITH RECURSIVE thread_tree AS (
+			SELECT m.id, m.channel_id, m.parent_id, m.user_id, m.content_md, m.content_html,
+				m.created_at, m.updated_at, m.is_edited, m.reply_to, m.forward_source_id,
+				0 AS depth
+			FROM messages m
+			WHERE m.id = $1
+			UNION ALL
+			SELECT m.id, m.channel_id, m.parent_id, m.user_id, m.content_md, m.content_html,
+				m.created_at, m.updated_at, m.is_edited, m.reply_to, m.forward_source_id,
+				tt.depth + 1
+			FROM messages m
+			JOIN thread_tree tt ON m.parent_id = tt.id
+		)
+		SELECT tt.id, tt.channel_id, tt.user_id, u.username, tt.parent_id, tt.reply_to, tt.forward_source_id,
 			fsu.username as forward_source_username,
-			m.content_md, m.content_html, m.created_at, m.updated_at, m.is_edited,
-			EXISTS(SELECT 1 FROM channel_pins cp WHERE cp.message_id = m.id) as is_pinned,
-			EXISTS(SELECT 1 FROM user_bookmarks ub WHERE ub.message_id = m.id AND ub.user_id = $2) as is_bookmarked 
-		FROM messages m
-		JOIN users u ON m.user_id = u.id
-		LEFT JOIN messages fsm ON m.forward_source_id = fsm.id
+			tt.content_md, tt.content_html, tt.created_at, tt.updated_at, tt.is_edited,
+			(SELECT COUNT(*) FROM messages r WHERE r.parent_id = tt.id) as reply_count,
+			EXISTS(SELECT 1 FROM channel_pins cp WHERE cp.message_id = tt.id) as is_pinned,
+			EXISTS(SELECT 1 FROM user_bookmarks ub WHERE ub.message_id = tt.id AND ub.user_id = $2) as is_bookmarked,
+			tt.depth
+		FROM thread_tree tt
+		JOIN users u ON tt.user_id = u.id
+		LEFT JOIN messages fsm ON tt.forward_source_id = fsm.id
 		LEFT JOIN users fsu ON fsm.user_id = fsu.id
-		WHERE m.parent_id = $1 
-		ORDER BY m.created_at ASC
+		WHERE tt.depth > 0
+		ORDER BY tt.depth ASC, tt.created_at ASC
 	`
 	rows, err := s.db.Pool.Query(ctx, query, messageID, currentUserID)
 	if err != nil {
@@ -297,15 +312,14 @@ func (s *MessagingService) GetThreadReplies(ctx context.Context, messageID strin
 	var messages []Message
 	for rows.Next() {
 		var msg Message
-		if err := rows.Scan(&msg.ID, &msg.ChannelID, &msg.UserID, &msg.Username, &msg.ParentID, &msg.ReplyTo, &msg.ForwardSourceID, &msg.ForwardSourceUsername, &msg.ContentMD, &msg.ContentHTML, &msg.CreatedAt, &msg.UpdatedAt, &msg.IsEdited, &msg.IsPinned, &msg.IsBookmarked); err != nil {
+		if err := rows.Scan(&msg.ID, &msg.ChannelID, &msg.UserID, &msg.Username, &msg.ParentID, &msg.ReplyTo, &msg.ForwardSourceID, &msg.ForwardSourceUsername, &msg.ContentMD, &msg.ContentHTML, &msg.CreatedAt, &msg.UpdatedAt, &msg.IsEdited, &msg.ReplyCount, &msg.IsPinned, &msg.IsBookmarked, &msg.Depth); err != nil {
 			return nil, err
 		}
-		msg.ReplyCount = 0 // Replies don't have replies in this simple 1-level thread model
 		messages = append(messages, msg)
 	}
-	
+
 	messages = s.Reactions.InjectReactionsIntoMessages(messages, currentUserID)
-	
+
 	return messages, nil
 }
 

--- a/ui/src/components/dashboard/ThreadPanel.tsx
+++ b/ui/src/components/dashboard/ThreadPanel.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import DOMPurify from 'dompurify';
-import { X, CornerDownRight, MessageCircle } from 'lucide-react';
+import { X, CornerDownRight, MessageCircle, ChevronDown, ChevronRight, Reply } from 'lucide-react';
 import { useMessageStore } from '../../stores/messageStore';
 import { renderMentionsInHTML } from '../../utils/mentions';
 import { PresenceAvatar } from '../common/PresenceAvatar';
@@ -10,32 +10,85 @@ interface ThreadPanelProps {
   channelId: string;
 }
 
+const MAX_INDENT_DEPTH = 10;
+
 export const ThreadPanel: React.FC<ThreadPanelProps> = ({ channelId }) => {
-  const { 
-    activeThreadId, 
-    setActiveThread, 
+  const {
+    activeThreadId,
+    setActiveThread,
     activeChannel,
-    messages, 
-    threadMessages, 
-    fetchThread, 
-    sendThreadReply, 
-    isLoading 
+    messages,
+    threadMessages,
+    fetchThread,
+    sendThreadReply,
+    isLoading
   } = useMessageStore();
-  
+
   const [replyInput, setReplyInput] = useState('');
-  
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
+  const [replyTargetId, setReplyTargetId] = useState<string | null>(null);
+
   const parentMessage = messages.find((m) => m.id === activeThreadId);
 
   useEffect(() => {
     if (activeThreadId && channelId) {
       fetchThread(channelId, activeThreadId);
+      setCollapsedIds(new Set());
+      setReplyTargetId(null);
     }
   }, [activeThreadId, channelId, fetchThread]);
 
+  // Build a set of all descendant IDs for collapsed messages so we can hide them
+  const hiddenIds = useMemo(() => {
+    if (collapsedIds.size === 0) return new Set<string>();
+
+    // Build parent->children map
+    const childrenMap = new Map<string, string[]>();
+    for (const msg of threadMessages) {
+      if (msg.parent_id) {
+        const siblings = childrenMap.get(msg.parent_id) || [];
+        siblings.push(msg.id);
+        childrenMap.set(msg.parent_id, siblings);
+      }
+    }
+
+    const hidden = new Set<string>();
+    const collectDescendants = (id: string) => {
+      const children = childrenMap.get(id) || [];
+      for (const childId of children) {
+        hidden.add(childId);
+        collectDescendants(childId);
+      }
+    };
+
+    collapsedIds.forEach((id) => collectDescendants(id));
+    return hidden;
+  }, [collapsedIds, threadMessages]);
+
+  const visibleMessages = useMemo(
+    () => threadMessages.filter((m) => !hiddenIds.has(m.id)),
+    [threadMessages, hiddenIds]
+  );
+
+  const toggleCollapse = useCallback((id: string) => {
+    setCollapsedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const effectiveParentId = replyTargetId || activeThreadId;
+
   const handleSend = async () => {
     if (!replyInput.trim() || !activeThreadId) return;
-    await sendThreadReply(channelId, activeThreadId, replyInput);
+    await sendThreadReply(channelId, effectiveParentId!, replyInput);
     setReplyInput('');
+    setReplyTargetId(null);
   };
 
   return (
@@ -73,10 +126,10 @@ export const ThreadPanel: React.FC<ThreadPanelProps> = ({ channelId }) => {
             {parentMessage && (
               <div className="p-4 border-b border-white/10 bg-blue-500/[0.03] border-l-2 border-l-blue-500/40">
                 <div className="flex items-start gap-4">
-                  <PresenceAvatar 
-                    userId={parentMessage.user_id} 
-                    username={parentMessage.username || 'U'} 
-                    size="md" 
+                  <PresenceAvatar
+                    userId={parentMessage.user_id}
+                    username={parentMessage.username || 'U'}
+                    size="md"
                   />
                   <div className="flex-1 min-w-0">
                     <div className="flex items-baseline gap-2 mb-1">
@@ -87,7 +140,7 @@ export const ThreadPanel: React.FC<ThreadPanelProps> = ({ channelId }) => {
                         {new Date(parentMessage.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                       </span>
                     </div>
-                    <div 
+                    <div
                       className="text-[15px] text-gray-300 leading-relaxed font-light whitespace-pre-wrap"
                       dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(renderMentionsInHTML(parentMessage.content_html || parentMessage.content_md), { ADD_ATTR: ['data-mention'] }) }}
                     />
@@ -97,7 +150,7 @@ export const ThreadPanel: React.FC<ThreadPanelProps> = ({ channelId }) => {
             )}
 
             {/* Replies List */}
-            <div className="flex-1 p-4 space-y-6">
+            <div className="flex-1 p-4 space-y-1">
               <div className="flex items-center gap-4 py-2">
                 <span className="text-[11px] font-bold uppercase tracking-wider text-gray-500">
                   {threadMessages.length} {threadMessages.length === 1 ? 'Reply' : 'Replies'}
@@ -111,41 +164,103 @@ export const ThreadPanel: React.FC<ThreadPanelProps> = ({ channelId }) => {
                   <span className="text-sm">Loading replies...</span>
                 </div>
               ) : (
-                threadMessages.map((reply) => (
-                  <div key={reply.id} className="group flex items-start gap-3 hover:bg-white/[0.01] -mx-2 px-2 py-1 rounded-xl transition-colors">
-                    <PresenceAvatar 
-                      userId={reply.user_id} 
-                      username={reply.username || 'U'} 
-                      size="sm" 
-                    />
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-baseline gap-2 mb-1">
-                        <span className="text-[14px] font-semibold text-gray-200">
-                          {reply.username || `User ${reply.user_id.substring(0, 4)}`}
-                        </span>
-                        <span className="text-[11px] text-gray-500 font-medium whitespace-nowrap">
-                          {new Date(reply.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                        </span>
+                visibleMessages.map((reply) => {
+                  const depth = reply.depth || 1;
+                  const indent = Math.min(depth - 1, MAX_INDENT_DEPTH) * 16;
+                  const hasReplies = (reply.reply_count || 0) > 0;
+                  const isCollapsed = collapsedIds.has(reply.id);
+
+                  return (
+                    <div
+                      key={reply.id}
+                      className="group"
+                      style={{ marginLeft: indent }}
+                    >
+                      {/* Left border for nested depth */}
+                      <div
+                        className={`flex items-start gap-3 hover:bg-white/[0.01] px-2 py-1.5 rounded-xl transition-colors ${
+                          depth > 1 ? 'border-l border-white/5 pl-3' : ''
+                        }`}
+                      >
+                        {/* Collapse toggle */}
+                        {hasReplies ? (
+                          <button
+                            onClick={() => toggleCollapse(reply.id)}
+                            className="mt-1 p-0.5 rounded text-gray-500 hover:text-gray-300 hover:bg-white/10 transition-colors flex-shrink-0"
+                            title={isCollapsed ? 'Expand replies' : 'Collapse replies'}
+                          >
+                            {isCollapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+                          </button>
+                        ) : (
+                          <div className="w-[18px] flex-shrink-0" />
+                        )}
+
+                        <PresenceAvatar
+                          userId={reply.user_id}
+                          username={reply.username || 'U'}
+                          size="sm"
+                        />
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-baseline gap-2 mb-0.5">
+                            <span className="text-[14px] font-semibold text-gray-200">
+                              {reply.username || `User ${reply.user_id.substring(0, 4)}`}
+                            </span>
+                            <span className="text-[11px] text-gray-500 font-medium whitespace-nowrap">
+                              {new Date(reply.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                            </span>
+                            {hasReplies && (
+                              <span className="text-[10px] text-gray-500">
+                                {reply.reply_count} {reply.reply_count === 1 ? 'reply' : 'replies'}
+                                {isCollapsed && ' (collapsed)'}
+                              </span>
+                            )}
+                          </div>
+                          <div
+                            className={`text-[14px] text-gray-400 leading-relaxed font-light whitespace-pre-wrap ${reply.status === 'sending' ? 'opacity-50' : ''}`}
+                            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(renderMentionsInHTML(reply.content_html || reply.content_md), { ADD_ATTR: ['data-mention'] }) }}
+                          />
+                          {reply.status === 'sending' && (
+                            <span className="text-[10px] text-gray-500 animate-pulse block mt-1">Sending...</span>
+                          )}
+                          {reply.status === 'error' && (
+                            <span className="text-[10px] text-red-500 block mt-1">Failed to send</span>
+                          )}
+                          {/* Reply button for nested replies */}
+                          <button
+                            onClick={() => setReplyTargetId(replyTargetId === reply.id ? null : reply.id)}
+                            className={`mt-1 flex items-center gap-1 text-[11px] font-medium transition-colors ${
+                              replyTargetId === reply.id
+                                ? 'text-blue-400'
+                                : 'text-gray-500 hover:text-gray-300 opacity-0 group-hover:opacity-100'
+                            }`}
+                          >
+                            <Reply size={12} />
+                            Reply
+                          </button>
+                        </div>
                       </div>
-                      <div 
-                        className={`text-[14px] text-gray-400 leading-relaxed font-light whitespace-pre-wrap ${reply.status === 'sending' ? 'opacity-50' : ''}`}
-                        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(renderMentionsInHTML(reply.content_html || reply.content_md), { ADD_ATTR: ['data-mention'] }) }}
-                      />
-                      {reply.status === 'sending' && (
-                        <span className="text-[10px] text-gray-500 animate-pulse block mt-1">Sending...</span>
-                      )}
-                      {reply.status === 'error' && (
-                        <span className="text-[10px] text-red-500 block mt-1">Failed to send</span>
-                      )}
                     </div>
-                  </div>
-                ))
+                  );
+                })
               )}
             </div>
           </div>
 
-          {/* Simple Reply Input below the list */}
+          {/* Reply Input */}
           <div className="p-4 w-full border-t border-white/10 shrink-0 bg-[#0a0e1a]">
+             {replyTargetId && (
+               <div className="flex items-center justify-between mb-2 px-2 py-1.5 bg-blue-500/5 border border-blue-500/10 rounded-lg">
+                 <span className="text-[11px] text-blue-400 font-medium">
+                   Replying to {threadMessages.find(m => m.id === replyTargetId)?.username || 'message'}
+                 </span>
+                 <button
+                   onClick={() => setReplyTargetId(null)}
+                   className="text-gray-500 hover:text-gray-300 transition-colors"
+                 >
+                   <X size={14} />
+                 </button>
+               </div>
+             )}
              <div className="bg-[#1a1a1a]/80 backdrop-blur border border-white/10 rounded-xl focus-within:border-blue-500/30 transition-all p-3 flex flex-col gap-2 shadow-2xl group relative">
                 <div className={`absolute -inset-0.5 bg-blue-500/10 rounded-xl blur transition-opacity opacity-0 group-focus-within:opacity-100 pointer-events-none`} />
                 <textarea
@@ -157,7 +272,7 @@ export const ThreadPanel: React.FC<ThreadPanelProps> = ({ channelId }) => {
                       handleSend();
                     }
                   }}
-                  placeholder="Reply to thread..."
+                  placeholder={replyTargetId ? 'Reply to this message...' : 'Reply to thread...'}
                   data-testid="thread-reply-input"
                   className="w-full bg-transparent text-gray-200 placeholder-gray-500 text-sm focus:outline-none resize-none min-h-[80px] relative z-10 custom-scrollbar"
                 />

--- a/ui/src/components/dashboard/ThreadPanel.tsx
+++ b/ui/src/components/dashboard/ThreadPanel.tsx
@@ -33,9 +33,11 @@ export const ThreadPanel: React.FC<ThreadPanelProps> = ({ channelId }) => {
   useEffect(() => {
     if (activeThreadId && channelId) {
       fetchThread(channelId, activeThreadId);
+    }
+    return () => {
       setCollapsedIds(new Set());
       setReplyTargetId(null);
-    }
+    };
   }, [activeThreadId, channelId, fetchThread]);
 
   // Build a set of all descendant IDs for collapsed messages so we can hide them

--- a/ui/src/stores/messageStore.ts
+++ b/ui/src/stores/messageStore.ts
@@ -35,6 +35,7 @@ export interface Message {
   is_bookmarked?: boolean;
   forward_source_id?: string;
   forward_source_username?: string;
+  depth?: number;
   created_at: string;
   updated_at: string;
   expires_at?: string;


### PR DESCRIPTION
## Summary
- PostgreSQL recursive CTE for unlimited-depth thread trees
- Depth field tracked per message in response
- UI renders up to 10 levels of nesting with indentation
- Collapse/expand toggle for nested threads
- Reply to any message in a thread (not just root)
- Reply count at each nesting level

## Test plan
- [ ] Thread replies can be nested multiple levels deep
- [ ] Depth renders with correct indentation in ThreadPanel
- [ ] Collapse/expand works for nested sub-threads
- [ ] Replying to a nested message creates proper parent_id relationship
- [ ] Performance acceptable for 100+ reply threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)