### PR TITLE
feat(#57): User onboarding wizard & workspace tour

### DIFF
--- a/ui/src/components/dashboard/MessageInput.tsx
+++ b/ui/src/components/dashboard/MessageInput.tsx
@@ -303,7 +303,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({ channelId }) => {
   }
 
   return (
-    <div className="p-6 bg-gradient-to-t from-[#030712] via-[#030712] to-transparent shrink-0">
+    <div className="p-6 bg-gradient-to-t from-[#030712] via-[#030712] to-transparent shrink-0" data-tour="message-input">
       <div className="max-w-4xl mx-auto relative group">
         <TypingIndicator channelId={channelId} />
         <ReplyPreview />

--- a/ui/src/components/dashboard/MessageItem.tsx
+++ b/ui/src/components/dashboard/MessageItem.tsx
@@ -257,10 +257,11 @@ export const MessageItem: React.FC<MessageItemProps> = ({
         </button>
         
         {!hideReply && (
-          <button 
+          <button
             onClick={() => setActiveThread(msg.id)}
             className="p-1.5 rounded-lg bg-[#2a2a2a] border border-white/5 text-gray-400 hover:text-white hover:bg-[#333] transition-all shadow-lg"
             title="Reply in thread"
+            data-tour="thread-hint"
           >
             <MessageCircle size={14} />
           </button>

--- a/ui/src/components/layout/DashboardLayout.tsx
+++ b/ui/src/components/layout/DashboardLayout.tsx
@@ -2,9 +2,14 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 import { useWebSocket } from '../../hooks/useWebSocket';
+import { useOnboardingStore } from '../../stores/onboardingStore';
+import { WelcomeWizard } from '../onboarding/WelcomeWizard';
+import { TourSpotlight } from '../onboarding/TourSpotlight';
 
 export const DashboardLayout: React.FC = () => {
   useWebSocket();
+
+  const { hasCompletedOnboarding, showTour } = useOnboardingStore();
 
   return (
     <div className="h-screen w-full bg-[#030712] flex overflow-hidden">
@@ -15,6 +20,9 @@ export const DashboardLayout: React.FC = () => {
           <Outlet />
         </div>
       </main>
+
+      {!hasCompletedOnboarding && <WelcomeWizard />}
+      {hasCompletedOnboarding && showTour && <TourSpotlight />}
     </div>
   );
 };

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -283,7 +283,7 @@ const handleNewDM = async (userId: string, _username: string) => {
   const displayOrgName = orgName || 'Nox Workspace';
 
   return (
-    <div className="w-64 h-full bg-[#0d0d0d] border-r border-white/5 flex flex-col pt-4 pb-4">
+    <div className="w-64 h-full bg-[#0d0d0d] border-r border-white/5 flex flex-col pt-4 pb-4" data-tour="sidebar">
 
       {/* Org Header with Switcher */}
       <div className="relative px-2 mb-6">
@@ -448,7 +448,7 @@ const handleNewDM = async (userId: string, _username: string) => {
         </div>
 
         <div>
-          <div className="px-3 mb-2 text-[11px] font-bold uppercase tracking-wider text-gray-500 flex items-center justify-between group">
+          <div className="px-3 mb-2 text-[11px] font-bold uppercase tracking-wider text-gray-500 flex items-center justify-between group" data-tour="channel-list">
             <span>Channels</span>
             <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
               <button

--- a/ui/src/components/onboarding/TourSpotlight.tsx
+++ b/ui/src/components/onboarding/TourSpotlight.tsx
@@ -1,0 +1,215 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ChevronRight, X } from 'lucide-react';
+import { useOnboardingStore } from '../../stores/onboardingStore';
+
+interface TourStep {
+  target: string; // CSS selector or data-testid value
+  title: string;
+  description: string;
+}
+
+const tourSteps: TourStep[] = [
+  {
+    target: '[data-tour="sidebar"]',
+    title: 'Navigation Hub',
+    description:
+      'This is your navigation hub. Find channels, DMs, and settings here.',
+  },
+  {
+    target: '[data-tour="channel-list"]',
+    title: 'Channel List',
+    description:
+      'Click a channel to start chatting. Create new ones with the + button.',
+  },
+  {
+    target: '[data-tour="message-input"]',
+    title: 'Message Input',
+    description:
+      'Type your message here. Use markdown for formatting.',
+  },
+  {
+    target: '[data-tour="thread-hint"]',
+    title: 'Threads',
+    description:
+      'Click "Reply" on any message to start a thread.',
+  },
+];
+
+interface SpotlightRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+export const TourSpotlight: React.FC = () => {
+  const { dismissTour } = useOnboardingStore();
+  const [step, setStep] = useState(0);
+  const [rect, setRect] = useState<SpotlightRect | null>(null);
+
+  const currentTourStep = tourSteps[step];
+
+  const updateRect = useCallback(() => {
+    if (!currentTourStep) return;
+    const el = document.querySelector(currentTourStep.target);
+    if (el) {
+      const r = el.getBoundingClientRect();
+      setRect({
+        top: r.top - 4,
+        left: r.left - 4,
+        width: r.width + 8,
+        height: r.height + 8,
+      });
+    } else {
+      setRect(null);
+    }
+  }, [currentTourStep]);
+
+  useEffect(() => {
+    updateRect();
+    window.addEventListener('resize', updateRect);
+    return () => window.removeEventListener('resize', updateRect);
+  }, [updateRect, step]);
+
+  const handleNext = () => {
+    if (step < tourSteps.length - 1) {
+      setStep(step + 1);
+    } else {
+      dismissTour();
+    }
+  };
+
+  const isLastStep = step === tourSteps.length - 1;
+
+  // Determine tooltip position relative to the spotlight
+  const getTooltipPosition = (): React.CSSProperties => {
+    if (!rect) {
+      return { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' };
+    }
+
+    const viewportWidth = window.innerWidth;
+    const tooltipWidth = 320;
+
+    // Place tooltip to the right of the element if room, otherwise below
+    if (rect.left + rect.width + tooltipWidth + 24 < viewportWidth) {
+      return {
+        top: rect.top + rect.height / 2,
+        left: rect.left + rect.width + 16,
+        transform: 'translateY(-50%)',
+      };
+    }
+
+    return {
+      top: rect.top + rect.height + 16,
+      left: Math.max(16, rect.left + rect.width / 2 - tooltipWidth / 2),
+      transform: 'none',
+    };
+  };
+
+  return (
+    <div className="fixed inset-0 z-[200]">
+      {/* Semi-transparent overlay with spotlight cutout via CSS clip-path */}
+      <svg className="absolute inset-0 w-full h-full" style={{ pointerEvents: 'none' }}>
+        <defs>
+          <mask id="tour-spotlight-mask">
+            <rect x="0" y="0" width="100%" height="100%" fill="white" />
+            {rect && (
+              <rect
+                x={rect.left}
+                y={rect.top}
+                width={rect.width}
+                height={rect.height}
+                rx="12"
+                fill="black"
+              />
+            )}
+          </mask>
+        </defs>
+        <rect
+          x="0"
+          y="0"
+          width="100%"
+          height="100%"
+          fill="rgba(0,0,0,0.7)"
+          mask="url(#tour-spotlight-mask)"
+        />
+      </svg>
+
+      {/* Spotlight border ring */}
+      {rect && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          className="absolute rounded-xl border-2 border-blue-500/60 pointer-events-none"
+          style={{
+            top: rect.top,
+            left: rect.left,
+            width: rect.width,
+            height: rect.height,
+          }}
+          layoutId="spotlight-ring"
+          transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+        />
+      )}
+
+      {/* Click catcher for dismiss */}
+      <div className="absolute inset-0" onClick={dismissTour} />
+
+      {/* Tooltip */}
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={step}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -10 }}
+          transition={{ duration: 0.2 }}
+          className="absolute w-80 bg-[#1a1a1a] border border-white/10 rounded-2xl shadow-2xl p-5 z-[201]"
+          style={getTooltipPosition()}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Step counter */}
+          <div className="flex items-center justify-between mb-3">
+            <span className="text-[11px] font-bold uppercase tracking-wider text-gray-500">
+              Step {step + 1} of {tourSteps.length}
+            </span>
+            <button
+              onClick={dismissTour}
+              className="p-1 hover:bg-white/10 rounded-full transition-colors text-gray-500 hover:text-white"
+              title="Skip tour"
+              data-testid="tour-skip"
+            >
+              <X size={14} />
+            </button>
+          </div>
+
+          <h3 className="text-base font-semibold text-white mb-1">{currentTourStep.title}</h3>
+          <p className="text-sm text-gray-400 leading-relaxed mb-4">{currentTourStep.description}</p>
+
+          {/* Step dots + next button */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5">
+              {tourSteps.map((_, i) => (
+                <div
+                  key={i}
+                  className={`w-1.5 h-1.5 rounded-full transition-colors ${
+                    i === step ? 'bg-blue-500' : i < step ? 'bg-blue-500/40' : 'bg-white/10'
+                  }`}
+                />
+              ))}
+            </div>
+
+            <button
+              onClick={handleNext}
+              className="flex items-center gap-1 px-4 py-1.5 bg-blue-500 hover:bg-blue-600 text-white rounded-lg text-sm font-medium transition-colors"
+              data-testid="tour-next"
+            >
+              {isLastStep ? 'Done' : 'Next'}
+              {!isLastStep && <ChevronRight size={14} />}
+            </button>
+          </div>
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+};

--- a/ui/src/components/onboarding/TourSpotlight.tsx
+++ b/ui/src/components/onboarding/TourSpotlight.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useReducer } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronRight, X } from 'lucide-react';
 import { useOnboardingStore } from '../../stores/onboardingStore';
@@ -46,31 +46,26 @@ interface SpotlightRect {
 export const TourSpotlight: React.FC = () => {
   const { dismissTour } = useOnboardingStore();
   const [step, setStep] = useState(0);
-  const [rect, setRect] = useState<SpotlightRect | null>(null);
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
 
   const currentTourStep = tourSteps[step];
 
-  const updateRect = useCallback(() => {
-    if (!currentTourStep) return;
+  // Compute rect directly during render (no effect needed)
+  const getRect = useCallback((): SpotlightRect | null => {
+    if (!currentTourStep) return null;
     const el = document.querySelector(currentTourStep.target);
-    if (el) {
-      const r = el.getBoundingClientRect();
-      setRect({
-        top: r.top - 4,
-        left: r.left - 4,
-        width: r.width + 8,
-        height: r.height + 8,
-      });
-    } else {
-      setRect(null);
-    }
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return { top: r.top - 4, left: r.left - 4, width: r.width + 8, height: r.height + 8 };
   }, [currentTourStep]);
 
+  const rect = getRect();
+
   useEffect(() => {
-    updateRect();
-    window.addEventListener('resize', updateRect);
-    return () => window.removeEventListener('resize', updateRect);
-  }, [updateRect, step]);
+    const handleResize = () => forceUpdate();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   const handleNext = () => {
     if (step < tourSteps.length - 1) {

--- a/ui/src/components/onboarding/WelcomeWizard.tsx
+++ b/ui/src/components/onboarding/WelcomeWizard.tsx
@@ -1,0 +1,357 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  Sparkles,
+  User,
+  Hash,
+  Lightbulb,
+  Rocket,
+  ChevronRight,
+  ChevronLeft,
+  X,
+  Users,
+  Command,
+  MessageSquareText,
+  Search,
+  HelpCircle,
+} from 'lucide-react';
+import { useOnboardingStore } from '../../stores/onboardingStore';
+import { useAuthStore } from '../../stores/authStore';
+import { useMessageStore, type BrowsableChannel } from '../../stores/messageStore';
+
+const stepIcons = [Sparkles, User, Hash, Lightbulb, Rocket];
+const stepLabels = ['Welcome', 'Profile', 'Channels', 'Tips', 'Ready'];
+
+// --- Step Components ---
+
+const WelcomeStep: React.FC = () => (
+  <div className="flex flex-col items-center text-center px-6 py-8">
+    <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center mb-6 shadow-lg shadow-blue-500/20">
+      <Sparkles size={36} className="text-white" />
+    </div>
+    <h2 className="text-3xl font-bold text-white mb-3">Welcome to Nox!</h2>
+    <p className="text-gray-400 text-base max-w-sm leading-relaxed">
+      Your modern workspace for team communication. Let's get you set up in just a few quick steps.
+    </p>
+  </div>
+);
+
+const ProfileStep: React.FC<{
+  displayName: string;
+  onDisplayNameChange: (val: string) => void;
+}> = ({ displayName, onDisplayNameChange }) => {
+  const { user } = useAuthStore();
+
+  return (
+    <div className="flex flex-col items-center text-center px-6 py-8">
+      <div className="w-20 h-20 rounded-full bg-gradient-to-br from-blue-500/20 to-purple-500/20 border-2 border-white/10 flex items-center justify-center mb-6">
+        <span className="text-3xl font-bold text-white">
+          {(user?.username || 'U').charAt(0).toUpperCase()}
+        </span>
+      </div>
+      <h2 className="text-2xl font-bold text-white mb-2">Your Profile</h2>
+      <p className="text-gray-400 text-sm mb-6 max-w-sm">
+        Confirm your display name. You can always change this later in settings.
+      </p>
+
+      <div className="w-full max-w-xs space-y-4 text-left">
+        <div>
+          <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
+            Username
+          </label>
+          <div className="px-3 py-2 bg-white/5 border border-white/10 rounded-xl text-sm text-gray-400">
+            {user?.username || 'unknown'}
+          </div>
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
+            Display Name
+          </label>
+          <input
+            type="text"
+            value={displayName}
+            onChange={(e) => onDisplayNameChange(e.target.value)}
+            placeholder="How should others see you?"
+            className="w-full px-3 py-2 bg-white/5 border border-white/10 rounded-xl text-white text-sm placeholder:text-gray-500 focus:outline-none focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/25"
+            data-testid="onboarding-display-name"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ChannelsStep: React.FC = () => {
+  const { browseChannels, joinChannel } = useMessageStore();
+  const [channels, setChannels] = useState<BrowsableChannel[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [joiningId, setJoiningId] = useState<string | null>(null);
+
+  const loadChannels = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await browseChannels();
+      setChannels(data);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, [browseChannels]);
+
+  useEffect(() => {
+    loadChannels();
+  }, [loadChannels]);
+
+  const handleJoin = async (channel: BrowsableChannel) => {
+    setJoiningId(channel.id);
+    try {
+      await joinChannel(channel.id);
+      setChannels((prev) =>
+        prev.map((ch) =>
+          ch.id === channel.id ? { ...ch, is_joined: true, member_count: ch.member_count + 1 } : ch
+        )
+      );
+    } catch {
+      // ignore
+    } finally {
+      setJoiningId(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center px-6 py-8">
+      <h2 className="text-2xl font-bold text-white mb-2">Join Channels</h2>
+      <p className="text-gray-400 text-sm mb-6 max-w-sm text-center">
+        Pick some channels to get started. You can always browse more later.
+      </p>
+
+      <div className="w-full max-w-sm max-h-56 overflow-y-auto space-y-1 custom-scrollbar">
+        {loading ? (
+          <div className="text-center text-gray-500 text-sm py-8">Loading channels...</div>
+        ) : channels.length === 0 ? (
+          <div className="text-center text-gray-500 text-sm py-8">No public channels available yet</div>
+        ) : (
+          channels.map((channel) => (
+            <motion.div
+              key={channel.id}
+              whileHover={{ backgroundColor: 'rgba(255,255,255,0.03)' }}
+              className="flex items-center justify-between p-3 rounded-xl"
+            >
+              <div className="flex items-center gap-2 min-w-0 flex-1 mr-3">
+                <Hash size={14} className="text-gray-500 flex-shrink-0" />
+                <div className="min-w-0">
+                  <span className="text-sm font-medium text-white truncate block">{channel.name}</span>
+                  <div className="flex items-center gap-1">
+                    <Users size={10} className="text-gray-600" />
+                    <span className="text-[11px] text-gray-600">{channel.member_count}</span>
+                  </div>
+                </div>
+              </div>
+              {channel.is_joined ? (
+                <span className="text-xs font-medium text-emerald-400 px-3 py-1.5">Joined</span>
+              ) : (
+                <button
+                  onClick={() => handleJoin(channel)}
+                  disabled={joiningId === channel.id}
+                  className="px-3 py-1.5 bg-blue-500 hover:bg-blue-600 disabled:opacity-50 rounded-lg text-xs font-medium text-white transition-colors"
+                  data-testid={`onboarding-join-${channel.id}`}
+                >
+                  {joiningId === channel.id ? '...' : 'Join'}
+                </button>
+              )}
+            </motion.div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+const TipsStep: React.FC = () => {
+  const tips = [
+    { icon: Search, label: 'Quick Search', shortcut: 'Cmd+K', description: 'Search messages, channels, and people' },
+    { icon: HelpCircle, label: 'Keyboard Shortcuts', shortcut: '?', description: 'View all available shortcuts' },
+    { icon: MessageSquareText, label: 'Threads', shortcut: '', description: 'Click "Reply" on any message to start a thread' },
+    { icon: Command, label: 'Markdown', shortcut: '', description: 'Use **bold**, *italic*, and `code` in messages' },
+  ];
+
+  return (
+    <div className="flex flex-col items-center px-6 py-8">
+      <h2 className="text-2xl font-bold text-white mb-2">Quick Tips</h2>
+      <p className="text-gray-400 text-sm mb-6 max-w-sm text-center">
+        A few handy features to help you get the most out of Nox.
+      </p>
+
+      <div className="w-full max-w-sm space-y-3">
+        {tips.map((tip) => (
+          <div
+            key={tip.label}
+            className="flex items-start gap-3 p-3 bg-white/5 border border-white/5 rounded-xl"
+          >
+            <div className="w-8 h-8 rounded-lg bg-blue-500/10 flex items-center justify-center flex-shrink-0">
+              <tip.icon size={16} className="text-blue-400" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-white">{tip.label}</span>
+                {tip.shortcut && (
+                  <kbd className="px-1.5 py-0.5 text-[10px] font-mono bg-white/10 border border-white/10 rounded text-gray-400">
+                    {tip.shortcut}
+                  </kbd>
+                )}
+              </div>
+              <p className="text-xs text-gray-500 mt-0.5">{tip.description}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const ReadyStep: React.FC = () => (
+  <div className="flex flex-col items-center text-center px-6 py-8">
+    <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-emerald-500 to-teal-600 flex items-center justify-center mb-6 shadow-lg shadow-emerald-500/20">
+      <Rocket size={36} className="text-white" />
+    </div>
+    <h2 className="text-3xl font-bold text-white mb-3">You're All Set!</h2>
+    <p className="text-gray-400 text-base max-w-sm leading-relaxed">
+      You're ready to start using Nox. Jump in, explore channels, and start collaborating with your team.
+    </p>
+  </div>
+);
+
+// --- Main Wizard ---
+
+export const WelcomeWizard: React.FC = () => {
+  const { currentStep, totalSteps, nextStep, prevStep, completeOnboarding, startTour } =
+    useOnboardingStore();
+  const { user } = useAuthStore();
+  const [displayName, setDisplayName] = useState(user?.fullName || user?.username || '');
+
+  const steps = [
+    <WelcomeStep key="welcome" />,
+    <ProfileStep key="profile" displayName={displayName} onDisplayNameChange={setDisplayName} />,
+    <ChannelsStep key="channels" />,
+    <TipsStep key="tips" />,
+    <ReadyStep key="ready" />,
+  ];
+
+  const handleSkip = () => {
+    completeOnboarding();
+  };
+
+  const handleFinish = () => {
+    completeOnboarding();
+    startTour();
+  };
+
+  const isLastStep = currentStep === totalSteps - 1;
+  const isFirstStep = currentStep === 0;
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/70 backdrop-blur-md">
+      <motion.div
+        initial={{ opacity: 0, scale: 0.9, y: 30 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+        className="w-full max-w-md bg-[#1a1a1a] border border-white/10 rounded-2xl overflow-hidden shadow-2xl"
+      >
+        {/* Step Indicator */}
+        <div className="flex items-center justify-between px-6 pt-5 pb-2">
+          <div className="flex items-center gap-2">
+            {stepIcons.map((Icon, i) => (
+              <button
+                key={i}
+                onClick={() => useOnboardingStore.getState().setStep(i)}
+                className={`w-8 h-8 rounded-full flex items-center justify-center transition-all ${
+                  i === currentStep
+                    ? 'bg-blue-500 text-white scale-110'
+                    : i < currentStep
+                      ? 'bg-blue-500/20 text-blue-400'
+                      : 'bg-white/5 text-gray-600'
+                }`}
+                title={stepLabels[i]}
+              >
+                <Icon size={14} />
+              </button>
+            ))}
+          </div>
+          <button
+            onClick={handleSkip}
+            className="text-xs text-gray-500 hover:text-gray-300 transition-colors flex items-center gap-1"
+            data-testid="onboarding-skip"
+          >
+            <X size={14} />
+            Skip
+          </button>
+        </div>
+
+        {/* Step Progress Bar */}
+        <div className="px-6 pb-2">
+          <div className="h-0.5 bg-white/5 rounded-full overflow-hidden">
+            <motion.div
+              className="h-full bg-blue-500 rounded-full"
+              initial={false}
+              animate={{ width: `${((currentStep + 1) / totalSteps) * 100}%` }}
+              transition={{ duration: 0.3 }}
+            />
+          </div>
+        </div>
+
+        {/* Step Content */}
+        <div className="relative min-h-[340px]">
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={currentStep}
+              initial={{ opacity: 0, x: 40 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -40 }}
+              transition={{ duration: 0.25 }}
+            >
+              {steps[currentStep]}
+            </motion.div>
+          </AnimatePresence>
+        </div>
+
+        {/* Navigation */}
+        <div className="flex items-center justify-between px-6 py-4 border-t border-white/5">
+          <button
+            onClick={prevStep}
+            disabled={isFirstStep}
+            className={`flex items-center gap-1 px-4 py-2 rounded-xl text-sm font-medium transition-colors ${
+              isFirstStep
+                ? 'text-gray-600 cursor-not-allowed'
+                : 'text-gray-400 hover:text-white hover:bg-white/5'
+            }`}
+            data-testid="onboarding-back"
+          >
+            <ChevronLeft size={16} />
+            Back
+          </button>
+
+          {isLastStep ? (
+            <button
+              onClick={handleFinish}
+              className="flex items-center gap-1 px-6 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-xl text-sm font-medium transition-colors shadow-lg shadow-blue-500/20"
+              data-testid="onboarding-finish"
+            >
+              <Rocket size={16} />
+              Start Using Nox
+            </button>
+          ) : (
+            <button
+              onClick={nextStep}
+              className="flex items-center gap-1 px-5 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-xl text-sm font-medium transition-colors shadow-lg shadow-blue-500/20"
+              data-testid="onboarding-next"
+            >
+              {isFirstStep ? 'Get Started' : 'Next'}
+              <ChevronRight size={16} />
+            </button>
+          )}
+        </div>
+      </motion.div>
+    </div>
+  );
+};

--- a/ui/src/stores/onboardingStore.ts
+++ b/ui/src/stores/onboardingStore.ts
@@ -1,0 +1,70 @@
+import { create } from 'zustand';
+
+const STORAGE_KEY = 'nox-onboarding-complete';
+
+interface OnboardingStore {
+  hasCompletedOnboarding: boolean;
+  currentStep: number;
+  totalSteps: number;
+  showTour: boolean;
+  completeOnboarding: () => void;
+  setStep: (step: number) => void;
+  nextStep: () => void;
+  prevStep: () => void;
+  startTour: () => void;
+  dismissTour: () => void;
+}
+
+export const useOnboardingStore = create<OnboardingStore>((set, get) => {
+  let completed = false;
+  try {
+    completed = localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    // ignore
+  }
+
+  return {
+    hasCompletedOnboarding: completed,
+    currentStep: 0,
+    totalSteps: 5,
+    showTour: false,
+
+    completeOnboarding: () => {
+      try {
+        localStorage.setItem(STORAGE_KEY, 'true');
+      } catch {
+        // ignore
+      }
+      set({ hasCompletedOnboarding: true, currentStep: 0 });
+    },
+
+    setStep: (step: number) => {
+      const { totalSteps } = get();
+      if (step >= 0 && step < totalSteps) {
+        set({ currentStep: step });
+      }
+    },
+
+    nextStep: () => {
+      const { currentStep, totalSteps } = get();
+      if (currentStep < totalSteps - 1) {
+        set({ currentStep: currentStep + 1 });
+      }
+    },
+
+    prevStep: () => {
+      const { currentStep } = get();
+      if (currentStep > 0) {
+        set({ currentStep: currentStep - 1 });
+      }
+    },
+
+    startTour: () => {
+      set({ showTour: true });
+    },
+
+    dismissTour: () => {
+      set({ showTour: false });
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- Multi-step welcome wizard for new users (Welcome → Profile → Join Channels → Tips → Ready)
- Interactive tour spotlight highlighting key UI areas
- Onboarding state persisted to localStorage
- Skip option available at any step
- Framer-motion animations for step transitions

## Test plan
- [ ] New users see welcome wizard on first login
- [ ] Tour highlights sidebar, channels, message input, threads
- [ ] Skip button completes onboarding immediately
- [ ] Onboarding doesn't re-appear after completion
- [ ] Step navigation (next/back) works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)