### PR TITLE
feat(#56): Email notification preferences & queue infrastructure

### DIFF
--- a/infra/db/schema.sql
+++ b/infra/db/schema.sql
@@ -383,3 +383,31 @@ CREATE INDEX IF NOT EXISTS idx_channel_categories_org ON channel_categories(org_
 
 ALTER TABLE channels ADD COLUMN IF NOT EXISTS category_id UUID REFERENCES channel_categories(id) ON DELETE SET NULL;
 ALTER TABLE channels ADD COLUMN IF NOT EXISTS position INT NOT NULL DEFAULT 0;
+
+-- 26. Email Notification Preferences (Issue #56)
+CREATE TABLE IF NOT EXISTS email_preferences (
+    user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    dm_emails BOOLEAN NOT NULL DEFAULT TRUE,
+    mention_emails BOOLEAN NOT NULL DEFAULT TRUE,
+    digest_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    digest_frequency VARCHAR(10) NOT NULL DEFAULT 'daily' CHECK (digest_frequency IN ('daily', 'weekly', 'never')),
+    unsubscribed BOOLEAN NOT NULL DEFAULT FALSE,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- 27. Email Queue (Issue #56)
+CREATE TABLE IF NOT EXISTS email_queue (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    email_type VARCHAR(20) NOT NULL CHECK (email_type IN ('dm', 'mention', 'digest')),
+    subject TEXT NOT NULL,
+    body_html TEXT NOT NULL,
+    body_text TEXT NOT NULL,
+    status VARCHAR(10) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'sent', 'failed')),
+    attempts INT NOT NULL DEFAULT 0,
+    last_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    sent_at TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS idx_email_queue_status ON email_queue(status, created_at);
+CREATE INDEX IF NOT EXISTS idx_email_queue_user ON email_queue(user_id, created_at DESC);

--- a/services/bifrost/cmd/gateway/main.go
+++ b/services/bifrost/cmd/gateway/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nox-labs/bifrost/internal/auth"
 	"github.com/nox-labs/bifrost/internal/db"
 	"github.com/nox-labs/bifrost/internal/messaging"
+	"github.com/nox-labs/bifrost/internal/email"
 	"github.com/nox-labs/bifrost/internal/notification"
 	"github.com/nox-labs/bifrost/internal/presence"
 	pb "github.com/nox-labs/bifrost/pkg/authv1/auth/v1"
@@ -107,6 +108,9 @@ func main() {
 	presenceHandler := presence.NewPresenceHandler(presenceService)
 	notificationService := notification.NewService(database)
 	notificationHandler := notification.NewHandler(notificationService)
+	emailSender := &email.LogSender{}
+	emailService := email.NewService(database, emailSender)
+	emailHandler := email.NewHandler(emailService)
 
 	// Serve uploaded avatars as static files
 	r.Static("/uploads", "./uploads")
@@ -128,6 +132,9 @@ func main() {
 
 		// Public invitation routes (no auth for viewing link info)
 		v1.GET("/join/:code", invitationHandler.GetInviteLinkInfo)
+
+		// Public email unsubscribe (no auth - clicked from email)
+		v1.GET("/email/unsubscribe/:token", emailHandler.Unsubscribe)
 
 		// Authenticated routes (require JWT)
 		authenticated := v1.Group("")
@@ -240,6 +247,10 @@ func main() {
 			authenticated.GET("/notifications/unread-count", notificationHandler.UnreadCount)
 			authenticated.PATCH("/notifications/:notificationId/read", notificationHandler.MarkRead)
 			authenticated.POST("/notifications/read-all", notificationHandler.MarkAllRead)
+
+			// Email Notification Preferences (Issue #56)
+			authenticated.GET("/email/preferences", emailHandler.GetPreferences)
+			authenticated.PATCH("/email/preferences", emailHandler.UpdatePreferences)
 
 			// Presence Routes
 			authenticated.POST("/presence/heartbeat", presenceHandler.Heartbeat)

--- a/services/bifrost/internal/email/handler.go
+++ b/services/bifrost/internal/email/handler.go
@@ -1,0 +1,81 @@
+package email
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Handler exposes HTTP endpoints for email notification preferences.
+type Handler struct {
+	service *Service
+}
+
+// NewHandler creates a new email handler.
+func NewHandler(service *Service) *Handler {
+	return &Handler{service: service}
+}
+
+// getUserID extracts the authenticated user ID set by AuthMiddleware.
+func getUserID(c *gin.Context) string {
+	userID, _ := c.Get("user_id")
+	s, _ := userID.(string)
+	return s
+}
+
+// GetPreferences returns the current user's email notification preferences.
+func (h *Handler) GetPreferences(c *gin.Context) {
+	userID := getUserID(c)
+	if userID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	prefs, err := h.service.GetPreferences(c.Request.Context(), userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, prefs)
+}
+
+// UpdatePreferences applies a partial update to the user's email preferences.
+func (h *Handler) UpdatePreferences(c *gin.Context) {
+	userID := getUserID(c)
+	if userID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	var req UpdatePreferencesRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+
+	prefs, err := h.service.UpdatePreferences(c.Request.Context(), userID, req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, prefs)
+}
+
+// Unsubscribe handles the one-click unsubscribe link. For now the token is
+// the user's UUID; a proper signed token should replace this in production.
+func (h *Handler) Unsubscribe(c *gin.Context) {
+	token := c.Param("token")
+	if token == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing token"})
+		return
+	}
+
+	if err := h.service.Unsubscribe(c.Request.Context(), token); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "unsubscribed"})
+}

--- a/services/bifrost/internal/email/models.go
+++ b/services/bifrost/internal/email/models.go
@@ -1,0 +1,38 @@
+package email
+
+import "time"
+
+// EmailPreference stores per-user email notification settings.
+type EmailPreference struct {
+	UserID          string    `json:"user_id"`
+	DMEmails        bool      `json:"dm_emails"`
+	MentionEmails   bool      `json:"mention_emails"`
+	DigestEnabled   bool      `json:"digest_enabled"`
+	DigestFrequency string    `json:"digest_frequency"`
+	Unsubscribed    bool      `json:"unsubscribed"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+// QueuedEmail represents a row in the email_queue table.
+type QueuedEmail struct {
+	ID        string     `json:"id"`
+	UserID    string     `json:"user_id"`
+	EmailType string     `json:"email_type"`
+	Subject   string     `json:"subject"`
+	BodyHTML  string     `json:"body_html"`
+	BodyText  string     `json:"body_text"`
+	Status    string     `json:"status"`
+	Attempts  int        `json:"attempts"`
+	LastError *string    `json:"last_error,omitempty"`
+	CreatedAt time.Time  `json:"created_at"`
+	SentAt    *time.Time `json:"sent_at,omitempty"`
+}
+
+// UpdatePreferencesRequest is the JSON body for PATCH /email/preferences.
+type UpdatePreferencesRequest struct {
+	DMEmails        *bool   `json:"dm_emails"`
+	MentionEmails   *bool   `json:"mention_emails"`
+	DigestEnabled   *bool   `json:"digest_enabled"`
+	DigestFrequency *string `json:"digest_frequency"`
+	Unsubscribed    *bool   `json:"unsubscribed"`
+}

--- a/services/bifrost/internal/email/sender.go
+++ b/services/bifrost/internal/email/sender.go
@@ -1,0 +1,20 @@
+package email
+
+import (
+	"context"
+	"log"
+)
+
+// Sender is the interface for delivering emails. Swap in a real
+// implementation (e.g. SES, SendGrid) when the project is ready.
+type Sender interface {
+	Send(ctx context.Context, to, subject, bodyHTML, bodyText string) error
+}
+
+// LogSender logs emails instead of sending them (for development).
+type LogSender struct{}
+
+func (s *LogSender) Send(ctx context.Context, to, subject, bodyHTML, bodyText string) error {
+	log.Printf("[EMAIL STUB] To: %s, Subject: %s", to, subject)
+	return nil
+}

--- a/services/bifrost/internal/email/service.go
+++ b/services/bifrost/internal/email/service.go
@@ -1,0 +1,191 @@
+package email
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/nox-labs/bifrost/internal/db"
+)
+
+// Service handles email preference management and the email queue.
+type Service struct {
+	db     *db.Database
+	sender Sender
+}
+
+// NewService creates an EmailService backed by the given database and sender.
+func NewService(database *db.Database, sender Sender) *Service {
+	return &Service{db: database, sender: sender}
+}
+
+// GetPreferences returns the email preferences for a user, inserting default
+// values if none exist yet.
+func (s *Service) GetPreferences(ctx context.Context, userID string) (*EmailPreference, error) {
+	var p EmailPreference
+	err := s.db.Pool.QueryRow(ctx, `
+		INSERT INTO email_preferences (user_id)
+		VALUES ($1)
+		ON CONFLICT (user_id) DO UPDATE SET user_id = email_preferences.user_id
+		RETURNING user_id, dm_emails, mention_emails, digest_enabled, digest_frequency, unsubscribed, updated_at
+	`, userID).Scan(
+		&p.UserID, &p.DMEmails, &p.MentionEmails,
+		&p.DigestEnabled, &p.DigestFrequency, &p.Unsubscribed, &p.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get email preferences: %w", err)
+	}
+	return &p, nil
+}
+
+// UpdatePreferences applies partial updates to a user's email preferences.
+func (s *Service) UpdatePreferences(ctx context.Context, userID string, req UpdatePreferencesRequest) (*EmailPreference, error) {
+	// Ensure the row exists first.
+	if _, err := s.GetPreferences(ctx, userID); err != nil {
+		return nil, err
+	}
+
+	// Build SET clause dynamically.
+	sets := "updated_at = NOW()"
+	args := []interface{}{userID}
+	idx := 2
+
+	if req.DMEmails != nil {
+		sets += fmt.Sprintf(", dm_emails = $%d", idx)
+		args = append(args, *req.DMEmails)
+		idx++
+	}
+	if req.MentionEmails != nil {
+		sets += fmt.Sprintf(", mention_emails = $%d", idx)
+		args = append(args, *req.MentionEmails)
+		idx++
+	}
+	if req.DigestEnabled != nil {
+		sets += fmt.Sprintf(", digest_enabled = $%d", idx)
+		args = append(args, *req.DigestEnabled)
+		idx++
+	}
+	if req.DigestFrequency != nil {
+		sets += fmt.Sprintf(", digest_frequency = $%d", idx)
+		args = append(args, *req.DigestFrequency)
+		idx++
+	}
+	if req.Unsubscribed != nil {
+		sets += fmt.Sprintf(", unsubscribed = $%d", idx)
+		args = append(args, *req.Unsubscribed)
+		idx++
+	}
+
+	var p EmailPreference
+	query := fmt.Sprintf(`UPDATE email_preferences SET %s WHERE user_id = $1
+		RETURNING user_id, dm_emails, mention_emails, digest_enabled, digest_frequency, unsubscribed, updated_at`, sets)
+	err := s.db.Pool.QueryRow(ctx, query, args...).Scan(
+		&p.UserID, &p.DMEmails, &p.MentionEmails,
+		&p.DigestEnabled, &p.DigestFrequency, &p.Unsubscribed, &p.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("update email preferences: %w", err)
+	}
+	return &p, nil
+}
+
+// QueueEmail inserts a new email into the queue for later processing.
+func (s *Service) QueueEmail(ctx context.Context, userID, emailType, subject, bodyHTML, bodyText string) (*QueuedEmail, error) {
+	var e QueuedEmail
+	err := s.db.Pool.QueryRow(ctx, `
+		INSERT INTO email_queue (user_id, email_type, subject, body_html, body_text)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id, user_id, email_type, subject, body_html, body_text, status, attempts, last_error, created_at, sent_at
+	`, userID, emailType, subject, bodyHTML, bodyText).Scan(
+		&e.ID, &e.UserID, &e.EmailType, &e.Subject,
+		&e.BodyHTML, &e.BodyText, &e.Status, &e.Attempts,
+		&e.LastError, &e.CreatedAt, &e.SentAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("queue email: %w", err)
+	}
+	return &e, nil
+}
+
+// ProcessQueue picks up pending emails and attempts to send them via the
+// configured Sender. Each email is retried up to 3 times before being
+// marked as failed.
+func (s *Service) ProcessQueue(ctx context.Context) (sent int, failed int, err error) {
+	rows, err := s.db.Pool.Query(ctx, `
+		SELECT id, user_id, email_type, subject, body_html, body_text, attempts
+		FROM email_queue
+		WHERE status = 'pending' AND attempts < 3
+		ORDER BY created_at ASC
+		LIMIT 50
+	`)
+	if err != nil {
+		return 0, 0, fmt.Errorf("process queue query: %w", err)
+	}
+	defer rows.Close()
+
+	type pending struct {
+		id, userID, emailType, subject, bodyHTML, bodyText string
+		attempts                                           int
+	}
+	var items []pending
+	for rows.Next() {
+		var p pending
+		if err := rows.Scan(&p.id, &p.userID, &p.emailType, &p.subject, &p.bodyHTML, &p.bodyText, &p.attempts); err != nil {
+			return sent, failed, fmt.Errorf("scan queue row: %w", err)
+		}
+		items = append(items, p)
+	}
+
+	for _, item := range items {
+		// Look up the user's email address.
+		var userEmail string
+		err := s.db.Pool.QueryRow(ctx, `SELECT email FROM users WHERE id = $1`, item.userID).Scan(&userEmail)
+		if err != nil {
+			if err == pgx.ErrNoRows {
+				// User deleted; mark as failed.
+				_, _ = s.db.Pool.Exec(ctx, `UPDATE email_queue SET status = 'failed', last_error = 'user not found' WHERE id = $1`, item.id)
+				failed++
+				continue
+			}
+			return sent, failed, fmt.Errorf("lookup user email: %w", err)
+		}
+
+		sendErr := s.sender.Send(ctx, userEmail, item.subject, item.bodyHTML, item.bodyText)
+		if sendErr != nil {
+			newAttempts := item.attempts + 1
+			newStatus := "pending"
+			if newAttempts >= 3 {
+				newStatus = "failed"
+				failed++
+			}
+			_, _ = s.db.Pool.Exec(ctx,
+				`UPDATE email_queue SET attempts = $1, status = $2, last_error = $3 WHERE id = $4`,
+				newAttempts, newStatus, sendErr.Error(), item.id,
+			)
+			continue
+		}
+
+		now := time.Now()
+		_, _ = s.db.Pool.Exec(ctx,
+			`UPDATE email_queue SET status = 'sent', attempts = attempts + 1, sent_at = $1 WHERE id = $2`,
+			now, item.id,
+		)
+		sent++
+	}
+
+	return sent, failed, nil
+}
+
+// Unsubscribe globally unsubscribes a user from all email notifications.
+func (s *Service) Unsubscribe(ctx context.Context, userID string) error {
+	_, err := s.db.Pool.Exec(ctx, `
+		INSERT INTO email_preferences (user_id, unsubscribed, updated_at)
+		VALUES ($1, TRUE, NOW())
+		ON CONFLICT (user_id) DO UPDATE SET unsubscribed = TRUE, updated_at = NOW()
+	`, userID)
+	if err != nil {
+		return fmt.Errorf("unsubscribe: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Email preferences table (DM emails, mention emails, digest settings)
- Email queue table for async delivery
- Sender interface with stub logger (ready for SendGrid/SES swap)
- GET/PATCH /email/preferences endpoints
- Unsubscribe endpoint
- Queue processing with retry logic

## Test plan
- [ ] Email preferences CRUD works via API
- [ ] Default preferences created for new users
- [ ] Unsubscribe sets preferences correctly
- [ ] Email queue accepts entries
- [ ] Stub sender logs emails to console

🤖 Generated with [Claude Code](https://claude.com/claude-code)